### PR TITLE
Restructure the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+![PyPI - Status](https://img.shields.io/pypi/status/crowdstrike-falconpy)<br/>
+![PyPI](https://img.shields.io/pypi/v/crowdstrike-falconpy) ![PyPI - Downloads](https://img.shields.io/pypi/dm/crowdstrike-falconpy)<br/>
+![PyPI - Implementation](https://img.shields.io/pypi/implementation/crowdstrike-falconpy) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/crowdstrike-falconpy) ![PyPI - Wheel](https://img.shields.io/pypi/wheel/crowdstrike-falconpy)<br/>
+![Twitter URL](https://img.shields.io/twitter/url?label=Follow%20%40CrowdStrike&style=social&url=https%3A%2F%2Ftwitter.com%2FCrowdStrike)<br/>
+
 # FalconPy
 The FalconPy SDK contains a collection of Python classes that abstract CrowdStrike Falcon OAuth2 API interaction, removing duplicative code and allowing developers to focus on just the logic of their solution requirements.
 

--- a/README.md
+++ b/README.md
@@ -1,76 +1,81 @@
-![PyPI - Status](https://img.shields.io/pypi/status/crowdstrike-falconpy)
-![PyPI](https://img.shields.io/pypi/v/crowdstrike-falconpy)
-![PyPI - Implementation](https://img.shields.io/pypi/implementation/crowdstrike-falconpy)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/crowdstrike-falconpy)
-![PyPI - Wheel](https://img.shields.io/pypi/wheel/crowdstrike-falconpy)
-![PyPI - Downloads](https://img.shields.io/pypi/dm/crowdstrike-falconpy)
-![Twitter URL](https://img.shields.io/twitter/url?label=Follow%20%40CrowdStrike&style=social&url=https%3A%2F%2Ftwitter.com%2FCrowdStrike)
-
 # FalconPy
-FalconPy provides a Python native harness for interacting with the CrowdStrike Falcon OAuth2 API.
+The FalconPy SDK contains a collection of Python classes that abstract CrowdStrike Falcon OAuth2 API interaction, removing duplicative code and allowing developers to focus on just the logic of their solution requirements.
 
-## Why FalconPy
-This project contains a collection of Python classes that abstract CrowdStrike Falcon API interaction, removing duplicative code and allowing developers to focus on just the logic of their solution requirements.
+This SDK provides two distinct methods for interacting with CrowdStrike's Falcon OAuth2 APIs:
+  * ***Service classes***, representing a single service collection, with methods defined for every available operation.
+  * ***The Uber class***, which provides a single harness for interacting with the entire API, covering every available operation within every service collection.
 
-## Contents
-Currently the solution defines a class for each service (_ex: cloud_connect_aws_), with endpoint methods defined as class methods. There is also a single _uber_-class that provides an interface to the entire API with a single handler.
-
-### Available classes
-+ [cloud_connect_aws.py](src/falconpy/cloud_connect_aws.py) - AWS Cloud
-+ [detects.py](src/falconpy/detects.py) - Detections
-+ [device_control_policies.py](src/falconpy/device_control_policies.py) - Device Control
-+ [event_streams.py](src/falconpy/event_streams.py) - Event Streams
-+ [falconx_sandbox.py](src/falconpy/falconx_sandbox.py) - The Falcon Sandbox
-+ [firewall_management.py](src/falconpy/firewall_management.py) - Firewall administration
-+ [firewall_policies.py](src/falconpy/firewall_policies.py) - Firewall policy management
-+ [host_group.py](src/falconpy/host_group.py) - Host groups
-+ [hosts.py](src/falconpy/hosts.py) - Hosts
-+ [incidents.py](src/falconpy/incidents.py) - Incidents
-+ [intel.py](src/falconpy/intel.py) - Threat Intel
-+ [iocs.py](src/falconpy/iocs.py) - Indicators of Compromise
-+ [oauth2.py](src/falconpy/oauth2.py) - OAuth2 authentication
-+ [prevention_policy.py](src/falconpy/prevention_policy.py) - Prevention policies
-+ [real_time_response_admin.py](src/falconpy/real_time_response_admin.py) - Real time response administration
-+ [real_time_response.py](src/falconpy/real_time_response.py) - Real time response
-+ [sensor_update_policy.py](src/falconpy/sensor_update_policy.py) - Sensor policy management
-+ [spotlight_vulnerabilities.py](src/falconpy/spotlight_vulnerabilities.py) - Vulnerabilities
-+ [user_management.py](src/falconpy/user_management.py) - User administration
-
-### Uber-class
-+ [api_complete.py](src/falconpy/api_complete.py) - CrowdStrike Falcon API full interface harness
-
-## Installation
-FalconPy is available on PyPI:
-```bash
+## Quick Install / Uninstall
+Stable releases of FalconPy are available on PyPI:
+```shell
 $ python -m pip install crowdstrike-falconpy
 ```
 
-## Documentation
-Documentation can be found in the [GitHub Wiki](https://github.com/CrowdStrike/falconpy/wiki).
+If you'd like to try the *absolute bleeding edge*, an automated GitHub action releases a test package with every merged pull request. To install the testing version:
+```shell
+$ python -m pip install -i https://test.pypi.org/simple/crowdstrike-falconpy
+```
 
-## License
-This is free and unencumbered software released into the public domain.
+To uninstall/remove FalconPy:
+```shell
+$ python -m pip uninstall crowdstrike-falconpy
+```
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+# Available Classes
+| OAuth2-Based API<br>*(CrowdStrike documentation, requires CrowdStrike customer login)* | Code Location |
+|:-|:-|
+| CrowdStrike Device Control API | [./src/falconpy/device_control_policies.py](./src/falconpy/device_control_policies.py) |
+| CrowdStrike Falcon Sandbox API | [./src/falconpy/falconx_sandbox.py](./src/falconpy/falconx_sandbox.py) |
+| CrowdStrike Sensor Policy Management API | [./src/falconpy/sensor_update_policy.py](./src/falconpy/sensor_update_policy.py) |
+| [CrowdStrike Custom Indicators of Compromose (IOCs) APIs](https://falcon.crowdstrike.com/support/documentation/88/custom-ioc-apis) | [./src/falconpy/iocs.py](./src/falconpy/iocs.py) |
+| [CrowdStrike Detections APIs](https://falcon.crowdstrike.com/support/documentation/85/detection-and-prevention-policies-apis) | [./src/falconpy/detects.py](./src/falconpy/detects.py) |
+| [CrowdStrike Event Streams API](https://falcon.crowdstrike.com/support/documentation/89/event-streams-apis)| [./serices/event_streams.py](./src/falconpy/event_streams.py) |
+| [CrowdStrike Event Streams APIs](https://falcon.crowdstrike.com/support/documentation/89/event-streams-apis) | *Coming Soon* |
+| [CrowdStrike Falcon Horizon APIs](https://falcon.crowdstrike.com/support/documentation/137/falcon-horizon-apis) | *Coming Soon* |
+| [CrowdStrike Falon X APIs](https://falcon.crowdstrike.com/support/documentation/92/falcon-x-apis) | *Coming Soon* |
+| [CrowdStrike Firewall Management API](https://falcon.crowdstrike.com/support/documentation/107/falcon-firewall-management-apis) | [./src/falconpy/firewall_management.py](./src/falconpy/firewall_management.py) |
+| [CrowdStrike Firewall Policy Management](https://falcon.crowdstrike.com/support/documentation/107/falcon-firewall-management-apis) | [./src/falconpy/firewall_policies.py](./src/falconpy/firewall_policies.py) |
+| [CrowdStrike Host Groups API](https://falcon.crowdstrike.com/support/documentation/84/host-and-host-group-management-apis) | [./src/falconpy/host_group.py](./src/falconpy/host_group.py) |
+| [CrowdStrike Hosts API](https://falcon.crowdstrike.com/support/documentation/84/host-and-host-group-management-apis) | [./src/falconpy/hosts.py](./src/falconpy/hosts.py) |
+| [CrowdStrike Incident and Detection Monitoring APIs](https://falcon.crowdstrike.com/support/documentation/86/detections-monitoring-apis) | [./src/falconpy/incidents.py](./src/falconpy/incidents.py) |
+| [CrowdStrike Installation Token APIs](https://falcon.crowdstrike.com/support/documentation/120/Installation-token-APIs) | *Coming Soon* | 
+| [CrowdStrike Intel API](https://falcon.crowdstrike.com/support/documentation/72/intel-apis) | [./src/falconpy/intel.py](./src/falconpy/intel.py) | 
+| [CrowdStrike MapQuery API](https://falcon.crowdstrike.com/support/documentation/113/malquery-apis) | *Coming Soon* |
+| [CrowdStrike OAuth2 Auth Token APIs](https://falcon.crowdstrike.com/support/documentation/93/oauth2-auth-token-apis) | [./src/falconpy/oauth2.py](./src/falconpy/oauth2.py) |
+| [CrowdStrike Prevention Policy APIs](https://falcon.crowdstrike.com/support/documentation/85/detection-and-prevention-policies-apis) | [./src/falconpy/prevention_policy.py](./src/falconpy/prevention_policy.py) |
+| [CrowdStrike Real Time Response (RTR) APIs](https://falcon.crowdstrike.com/support/documentation/90/real-time-response-apis) | [./src/falconpy/real_time_response.py](./src/falconpy/real_time_response.py) |
+| [CrowdStrike Realtime Response (RTR) Administration API](https://falcon.crowdstrike.com/support/documentation/90/real-time-response-apis) | [./src/falconpy/real_time_response_admin.py](./src/falconpy/real_time_response_admin.py) |
+| [CrowdStrike Sensor Download APIs](https://falcon.crowdstrike.com/support/documentation/109/sensor-download-apis) | *Coming Soon* |
+| [CrowdStrike Spotlight APIs](https://falcon.crowdstrike.com/support/documentation/98/spotlight-apis) | [./src/falconpy/spotlight_vulnerabilities.py](./src/falconpy/spotlight_vulnerabilities.py) |
+| [CrowdStrike User and Roles API](https://falcon.crowdstrike.com/support/documentation/87/users-and-roles-apis) | [./src/falconpy/user_management.py](./src/falconpy/user_management.py) | 
+| [Falcon Discover for Cloud and Containers - AWS Accounts APIs](https://falcon.crowdstrike.com/support/documentation/91/discover-for-aws-apis) | [./src/falconpy/cloud_connect_aws.py](./src/falconpy/cloud_connect_aws.py) |
+| [Falcon Discover for Cloud and Containers - Azure Subscriptions APIs](https://falcon.crowdstrike.com/support/documentation/118/falcon-discover-for-cloud-and-containers-azure-subscription-apis) | *Coming Soon* |
+| [Falcon Discover for Cloud and Containers - GCP Projects APIs](https://falcon.crowdstrike.com/support/documentation/117/falcon-discover-for-cloud-and-containers-gcp-projects-apis) | *Coming Soon* |
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
+## Uber-class
++ [./src/falconpy/api_complete.py](./src/falconpy/api_complete.py) - Provides an interface to all CrowdStrike APIs with a single handler.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+# Contributing
+There are *many* ways you can contribute to the FalconPy project!
+  * ***Providing feedback*** by opening a GitHub ticket. Even a fly-by "Hey, this worked!" is appreciated and helps validate approaches. Ideas on improving the project are most welcome.
+  * ***Documenting, blogging, or creating videos***, of how you've used FalconPy! This type of content is *invaluable* and helps communities grow. Open a pull request for inclusion in the [Documentation and Collateral](#documentation-and-collateral) section.
+  * ***Fix a bug or implement a new feature***. Check out our [open issues on GitHub](https://github.com/CrowdStrike/falconpy/issues) for inspiration.
+  * ***Review pull requests*** by going through the queue of [open pull requests on GitHub](https://github.com/CrowdStrike/falconpy/pulls) and giving feedback to the authors
 
-For more information, please refer to <https://unlicense.org>
+Open to do something else but not sure where to start? Try [opening an issue](https://github.com/CrowdStrike/falconpy/issues/new) and introducing yourself and your interests. We look forward to chatting with you!
 
+# Support
+FalconPy is an open source project to assist developers implement CrowdStrike's APIs within their applications. As such it carries no formal support, express or implied. 
+
+# Documentation & Collateral
+
+## Official Project Documentation
+
+## Videos (Tutorials, Trainings, Overviews)
+*Coming soon*.
+
+## Conference Presentations
+*Coming soon.*
+
+## Blogs/Articles/Prose
+*Coming soon*.


### PR DESCRIPTION
Mostly re-arranges the content in an attempt to increase clarity. The ``available classes`` still has the same stuff but sorted alphabetically. Added placeholders for APIs that are listed on the CrowdStrike API spec but not present here.