### PR TITLE
Create GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help FalconPy improve.
+title: "[ BUG ] ..."
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Red Hat Enterprise Linux 8.3]
+ - Python [e.g. 3.9]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for FalconPy
+title: "[Feature]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+Is your objective doable today, but the current implementation is somehow non-ideal? A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Help us mindmeld! Add any other context or screenshots about the feature request here. Pictures and diagrams are especially helpful.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,9 @@
+---
+name: General Question
+about: Got a question? Ask it here.
+title: "[Question] ..."
+labels: question
+assignees: ''
+
+---
+


### PR DESCRIPTION
When people click to create a new issue, they'll be presented with this screen:

![image](https://user-images.githubusercontent.com/5713754/101428826-87a42780-38cf-11eb-96e8-91abfa164900.png)


After selecting an option they'll be presented with a tailored "new issue" form:
![image](https://user-images.githubusercontent.com/5713754/101428856-9559ad00-38cf-11eb-9ea2-593e8b78e291.png)

Over time we can customize these further (e.g. once we know what kind of information we *always* end up asking for in bug reports).