### PR TITLE
Switch github action to use CI environment

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
 
+    environment: ci
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This makes a use of github feature called Environments (not to confuse with
github virtual environments, not to confuse with environment variables).

This will allow us to share github secrets across the forks. An new contributor
to our repository won't be able to run CI, until one of the admins approve. This
way we avoid secret reveal.

https://github.blog/changelog/2020-12-15-github-actions-environments-environment-protection-rules-and-environment-secrets-beta/