### PR TITLE
MSSP targeting token authentication fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="crowdstrike-falconpy",
-    version="0.2.0",
+    version="0.2.1",
     author="CrowdStrike",
     maintainer="Joshua Hiller",
     description="The CrowdStrike Falcon API SDK for Python 3",

--- a/src/falconpy/__init__.py
+++ b/src/falconpy/__init__.py
@@ -4,7 +4,7 @@ falconpy
 The CrowdStrike Falcon API SDK
 """
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 __maintainer__ = 'Joshua Hiller'
 __author__ = 'CrowdStrike'
 __credits__ = 'CrowdStrike'

--- a/src/falconpy/api_complete.py
+++ b/src/falconpy/api_complete.py
@@ -347,10 +347,7 @@ class APIHarness:
         FULL_URL = self.base_url+'/oauth2/token'
         DATA = {}
         if self.valid_cred_format():
-            DATA = {
-                'client_id': self.creds['client_id'],
-                'client_secret': self.creds['client_secret']
-            }
+            DATA=self.creds
         try:
             response = requests.request("POST", FULL_URL, data=DATA, headers={}, verify=False)
             result = self.Result()(status_code=response.status_code,headers={},body=response.json())["body"]

--- a/src/falconpy/oauth2.py
+++ b/src/falconpy/oauth2.py
@@ -73,6 +73,8 @@ class OAuth2:
             'client_id': self.creds['client_id'],
             'client_secret': self.creds['client_secret']
         }
+        if "member_cid" in self.creds:
+            DATA["member_cid"] = self.creds["member_cid"]
         try:
             response = requests.request("POST", FULL_URL, data=DATA, headers=HEADERS, verify=False)
             returned = self.Result()(response.status_code,response.json())

--- a/tests/test_intel.py
+++ b/tests/test_intel.py
@@ -37,7 +37,7 @@ class TestIntel:
             return False
 
     def serviceIntel_GetIntelActorEntities(self):
-        if falcon.GetIntelActorEntities(ids=falcon.QueryIntelActorEntities(parameters={"limit":1})["body"]["resources"][0])["status_code"] in AllowedResponses:
+        if falcon.GetIntelActorEntities(ids=falcon.QueryIntelActorEntities(parameters={"limit":1})["body"]["resources"][0]["id"])["status_code"] in AllowedResponses:
             return True
         else:
             return False
@@ -49,7 +49,7 @@ class TestIntel:
             return False
     
     def serviceIntel_GetIntelReportEntities(self):
-        if falcon.GetIntelReportEntities(ids=falcon.QueryIntelReportEntities(parameters={"limit":1})["body"]["resources"][0])["status_code"] in AllowedResponses:
+        if falcon.GetIntelReportEntities(ids=falcon.QueryIntelReportEntities(parameters={"limit":1})["body"]["resources"][0]["id"])["status_code"] in AllowedResponses:
             return True
         else:
             return False


### PR DESCRIPTION
This PR contains fixes for generating tokens that support MSSP member CID targeting.

- NOT a Breaking Change
- [x] Backwards compatible
- NO unit tests included

This PR also contains fixes related to two unit tests for the Falcon Intel service class.