### PR TITLE
Configurable SSL verification options, Disable Python 3.5 testing

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,5 +39,5 @@ jobs:
         DEBUG_API_ID: ${{ secrets.DEBUG_API_ID }}
         DEBUG_API_SECRET: ${{ secrets.DEBUG_API_SECRET }}
       run: |
-        coverage run --source src -m pytest -s -W ignore::Warning
+        coverage run --source src -m pytest -s
         coverage report

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="crowdstrike-falconpy",
-    version="0.2.3",
+    version="0.3.0",
     author="CrowdStrike",
     maintainer="Joshua Hiller",
     description="The CrowdStrike Falcon API SDK for Python 3",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="crowdstrike-falconpy",
-    version="0.2.2",
+    version="0.2.3",
     author="CrowdStrike",
     maintainer="Joshua Hiller",
     description="The CrowdStrike Falcon API SDK for Python 3",

--- a/src/falconpy/__init__.py
+++ b/src/falconpy/__init__.py
@@ -4,7 +4,7 @@ falconpy
 The CrowdStrike Falcon API SDK
 """
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 __maintainer__ = 'Joshua Hiller'
 __author__ = 'CrowdStrike'
 __credits__ = 'CrowdStrike'

--- a/src/falconpy/__init__.py
+++ b/src/falconpy/__init__.py
@@ -4,7 +4,7 @@ falconpy
 The CrowdStrike Falcon API SDK
 """
 
-__version__ = '0.2.3'
+__version__ = '0.3.0'
 __maintainer__ = 'Joshua Hiller'
 __author__ = 'CrowdStrike'
 __credits__ = 'CrowdStrike'

--- a/src/falconpy/cloud_connect_aws.py
+++ b/src/falconpy/cloud_connect_aws.py
@@ -40,12 +40,13 @@ class Cloud_Connect_AWS:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url="https://api.crowdstrike.com"):
+    def __init__(self, access_token, base_url="https://api.crowdstrike.com", ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = {'Authorization': 'Bearer {}'.format(access_token)}
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -70,7 +71,7 @@ class Cloud_Connect_AWS:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -83,7 +84,7 @@ class Cloud_Connect_AWS:
         FULL_URL = self.base_url+'/cloud-connect-aws/combined/settings/v1'
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -97,7 +98,7 @@ class Cloud_Connect_AWS:
         FULL_URL = self.base_url+'/cloud-connect-aws/entities/accounts/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -111,7 +112,7 @@ class Cloud_Connect_AWS:
         PARAMS=parameters
         BODY=body
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=self.headers, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=self.headers, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -124,7 +125,7 @@ class Cloud_Connect_AWS:
         ID_LIST = str(ids).replace(",","&ids=")
         FULL_URL = self.base_url+'/cloud-connect-aws/entities/accounts/v1?ids={}'.format(ID_LIST)
         try:
-            response = requests.request("DELETE", FULL_URL, headers=self.headers, verify=False)
+            response = requests.request("DELETE", FULL_URL, headers=self.headers, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -137,7 +138,7 @@ class Cloud_Connect_AWS:
         FULL_URL = self.base_url+'/cloud-connect-aws/entities/accounts/v1'
         BODY=body
         try:
-            response = requests.request("PATCH", FULL_URL, json=BODY, headers=self.headers, verify=False)
+            response = requests.request("PATCH", FULL_URL, json=BODY, headers=self.headers, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -151,7 +152,7 @@ class Cloud_Connect_AWS:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -166,7 +167,7 @@ class Cloud_Connect_AWS:
         HEADERS = self.headers
         BODY=body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -182,7 +183,7 @@ class Cloud_Connect_AWS:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/detects.py
+++ b/src/falconpy/detects.py
@@ -40,12 +40,13 @@ class Detects:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -68,7 +69,7 @@ class Detects:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -82,7 +83,7 @@ class Detects:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("PATCH", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("PATCH", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -96,7 +97,7 @@ class Detects:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -110,7 +111,7 @@ class Detects:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/device_control_policies.py
+++ b/src/falconpy/device_control_policies.py
@@ -40,12 +40,13 @@ class Device_Control_Policies:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -70,7 +71,7 @@ class Device_Control_Policies:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -86,7 +87,7 @@ class Device_Control_Policies:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -103,7 +104,7 @@ class Device_Control_Policies:
         BODY = body
         PARAMS = parameters
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -120,7 +121,7 @@ class Device_Control_Policies:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -134,7 +135,7 @@ class Device_Control_Policies:
         FULL_URL = self.base_url+'/policy/entities/device-control/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -148,7 +149,7 @@ class Device_Control_Policies:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -162,7 +163,7 @@ class Device_Control_Policies:
         FULL_URL = self.base_url+'/policy/entities/device-control/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -176,7 +177,7 @@ class Device_Control_Policies:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("PATCH", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("PATCH", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -192,7 +193,7 @@ class Device_Control_Policies:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -208,7 +209,7 @@ class Device_Control_Policies:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/event_streams.py
+++ b/src/falconpy/event_streams.py
@@ -40,12 +40,13 @@ class Event_Streams:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url="https://api.crowdstrike.com"):
+    def __init__(self, access_token, base_url="https://api.crowdstrike.com", ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -68,7 +69,7 @@ class Event_Streams:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("POST", FULL_URL, json={}, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json={}, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
             
         except Exception as e:
@@ -83,7 +84,7 @@ class Event_Streams:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
             
         except Exception as e:

--- a/src/falconpy/falconx_sandbox.py
+++ b/src/falconpy/falconx_sandbox.py
@@ -40,12 +40,13 @@ class FalconX_Sandbox:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -69,7 +70,7 @@ class FalconX_Sandbox:
         HEADERS['Accept-Encoding'] = 'gzip' #Force gzip compression
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             if response.headers.get('content-type') == "application/json":
                 returned = self.Result()(response.status_code, response.headers, response.json())
             else:
@@ -86,7 +87,7 @@ class FalconX_Sandbox:
         FULL_URL = self.base_url+'/falconx/entities/report-summaries/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -100,7 +101,7 @@ class FalconX_Sandbox:
         FULL_URL = self.base_url+'/falconx/entities/submissions/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -114,7 +115,7 @@ class FalconX_Sandbox:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -128,7 +129,7 @@ class FalconX_Sandbox:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -144,7 +145,7 @@ class FalconX_Sandbox:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -160,7 +161,7 @@ class FalconX_Sandbox:
         BODY = body
         PARAMS = parameters
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, data=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, data=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/firewall_management.py
+++ b/src/falconpy/firewall_management.py
@@ -40,12 +40,13 @@ class Firewall_Management:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -68,7 +69,7 @@ class Firewall_Management:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -82,7 +83,7 @@ class Firewall_Management:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -96,7 +97,7 @@ class Firewall_Management:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -110,7 +111,7 @@ class Firewall_Management:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -124,7 +125,7 @@ class Firewall_Management:
         FULL_URL = self.base_url+'/fwmgr/entities/events/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -138,7 +139,7 @@ class Firewall_Management:
         FULL_URL = self.base_url+'/fwmgr/entities/firewall-fields/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -152,7 +153,7 @@ class Firewall_Management:
         FULL_URL = self.base_url+'/fwmgr/entities/platforms/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -166,7 +167,7 @@ class Firewall_Management:
         FULL_URL = self.base_url+'/fwmgr/entities/policies/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -182,7 +183,7 @@ class Firewall_Management:
         HEADERS['X-CS-USERNAME'] = cs_username
         BODY = body
         try:
-            response = requests.request("PUT", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("PUT", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -196,7 +197,7 @@ class Firewall_Management:
         FULL_URL = self.base_url+'/fwmgr/entities/rule-groups/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -212,7 +213,7 @@ class Firewall_Management:
         PARAMS = parameters
         BODY = body        
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -228,7 +229,7 @@ class Firewall_Management:
         HEADERS['X-CS-USERNAME'] = cs_username
         PARAMS = parameters
         try:
-            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -244,7 +245,7 @@ class Firewall_Management:
         PARAMS = parameters
         BODY = body
         try:
-            response = requests.request("PTACH", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("PTACH", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -258,7 +259,7 @@ class Firewall_Management:
         FULL_URL = self.base_url+'/fwmgr/entities/rules/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -272,7 +273,7 @@ class Firewall_Management:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -286,7 +287,7 @@ class Firewall_Management:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -300,7 +301,7 @@ class Firewall_Management:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -314,7 +315,7 @@ class Firewall_Management:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -328,7 +329,7 @@ class Firewall_Management:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -342,7 +343,7 @@ class Firewall_Management:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/firewall_policies.py
+++ b/src/falconpy/firewall_policies.py
@@ -40,12 +40,13 @@ class Firewall_Policies:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -70,7 +71,7 @@ class Firewall_Policies:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -86,7 +87,7 @@ class Firewall_Policies:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -101,7 +102,7 @@ class Firewall_Policies:
         BODY = body
         PARAMS = parameters
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -118,7 +119,7 @@ class Firewall_Policies:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -132,7 +133,7 @@ class Firewall_Policies:
         FULL_URL = self.base_url+'/policy/entities/firewall/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -147,7 +148,7 @@ class Firewall_Policies:
         PARAMS = parameters
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -161,7 +162,7 @@ class Firewall_Policies:
         FULL_URL = self.base_url+'/policy/entities/firewall/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -175,7 +176,7 @@ class Firewall_Policies:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("PATCH", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("PATCH", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -191,7 +192,7 @@ class Firewall_Policies:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -207,7 +208,7 @@ class Firewall_Policies:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/host_group.py
+++ b/src/falconpy/host_group.py
@@ -40,12 +40,13 @@ class Host_Group:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -70,7 +71,7 @@ class Host_Group:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -86,7 +87,7 @@ class Host_Group:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -101,7 +102,7 @@ class Host_Group:
         PARAMS = parameters
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -115,7 +116,7 @@ class Host_Group:
         FULL_URL = self.base_url+'/devices/entities/host-groups/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -129,7 +130,7 @@ class Host_Group:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -143,7 +144,7 @@ class Host_Group:
         FULL_URL = self.base_url+'/devices/entities/host-groups/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -156,7 +157,7 @@ class Host_Group:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("PATCH", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("PATCH", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -172,7 +173,7 @@ class Host_Group:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -188,7 +189,7 @@ class Host_Group:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/hosts.py
+++ b/src/falconpy/hosts.py
@@ -40,12 +40,13 @@ class Hosts:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -69,7 +70,7 @@ class Hosts:
         PARAMS = parameters
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -85,7 +86,7 @@ class Hosts:
         FULL_URL = self.base_url+'/devices/entities/devices/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -99,7 +100,7 @@ class Hosts:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -113,7 +114,7 @@ class Hosts:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -127,7 +128,7 @@ class Hosts:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/incidents.py
+++ b/src/falconpy/incidents.py
@@ -40,12 +40,13 @@ class Incidents:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -68,7 +69,7 @@ class Incidents:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -82,7 +83,7 @@ class Incidents:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -98,7 +99,7 @@ class Incidents:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -112,7 +113,7 @@ class Incidents:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -126,7 +127,7 @@ class Incidents:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -140,7 +141,7 @@ class Incidents:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/intel.py
+++ b/src/falconpy/intel.py
@@ -40,12 +40,13 @@ class Intel:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -68,7 +69,7 @@ class Intel:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -82,7 +83,7 @@ class Intel:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -96,7 +97,7 @@ class Intel:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -111,7 +112,7 @@ class Intel:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -125,7 +126,7 @@ class Intel:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -139,7 +140,7 @@ class Intel:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             if response.headers.get('content-type') == "application/json":
                 returned = self.Result()(response.status_code, response.headers, response.json())
             else:
@@ -157,7 +158,7 @@ class Intel:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -171,7 +172,7 @@ class Intel:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             if response.headers.get('content-type') == "application/json":
                 returned = self.Result()(response.status_code, response.headers, response.json())
             else:
@@ -188,7 +189,7 @@ class Intel:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -202,7 +203,7 @@ class Intel:
         FULL_URL = self.base_url+'/intel/entities/rules/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -216,7 +217,7 @@ class Intel:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -230,7 +231,7 @@ class Intel:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -244,7 +245,7 @@ class Intel:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -258,7 +259,7 @@ class Intel:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/iocs.py
+++ b/src/falconpy/iocs.py
@@ -40,12 +40,13 @@ class Iocs:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -68,7 +69,7 @@ class Iocs:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -82,7 +83,7 @@ class Iocs:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -96,7 +97,7 @@ class Iocs:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -110,7 +111,7 @@ class Iocs:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -125,7 +126,7 @@ class Iocs:
         PARAMS = parameters
         BODY = body
         try:
-            response = requests.request("PATCH", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("PATCH", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -139,7 +140,7 @@ class Iocs:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -153,7 +154,7 @@ class Iocs:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -167,7 +168,7 @@ class Iocs:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -181,7 +182,7 @@ class Iocs:
         FULL_URL = self.base_url+'/processes/entities/processes/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/oauth2.py
+++ b/src/falconpy/oauth2.py
@@ -47,10 +47,11 @@ class OAuth2:
         }
     """
 
-    def __init__(self, creds, base_url="https://api.crowdstrike.com"):
+    def __init__(self, creds, base_url="https://api.crowdstrike.com", ssl_verify=True):
         """ Initializes the base class, ingesting credentials and the base URL. """
         self.creds = creds
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -76,7 +77,7 @@ class OAuth2:
         if "member_cid" in self.creds:
             DATA["member_cid"] = self.creds["member_cid"]
         try:
-            response = requests.request("POST", FULL_URL, data=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, data=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code,response.json())
         except Exception as e:
             returned = self.Result()(500, str(e))
@@ -89,7 +90,7 @@ class OAuth2:
         HEADERS = { 'Authorization': 'basic {}'.format(token) }
         DATA = { 'token': '{}'.format(token) }
         try:
-            response = requests.request("POST", FULL_URL, data=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, data=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.json())
         except Exception as e:
             returned = self.Result()(500, str(e))

--- a/src/falconpy/prevention_policy.py
+++ b/src/falconpy/prevention_policy.py
@@ -40,12 +40,13 @@ class Prevention_Policy:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -70,7 +71,7 @@ class Prevention_Policy:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -86,7 +87,7 @@ class Prevention_Policy:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -101,7 +102,7 @@ class Prevention_Policy:
         PARAMS = parameters
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -118,7 +119,7 @@ class Prevention_Policy:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -132,7 +133,7 @@ class Prevention_Policy:
         FULL_URL = self.base_url+'/policy/entities/prevention/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -146,7 +147,7 @@ class Prevention_Policy:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -160,7 +161,7 @@ class Prevention_Policy:
         FULL_URL = self.base_url+'/policy/entities/prevention/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -174,7 +175,7 @@ class Prevention_Policy:
         HEADERS = self.headers
         BODY = body
         try:
-            response = requests.request("PATCH", FULL_URL, json=BODY, headers=HEADERS, verify=False)
+            response = requests.request("PATCH", FULL_URL, json=BODY, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -190,7 +191,7 @@ class Prevention_Policy:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -206,7 +207,7 @@ class Prevention_Policy:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/real_time_response.py
+++ b/src/falconpy/real_time_response.py
@@ -40,12 +40,13 @@ class Real_Time_Response:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -68,7 +69,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -83,7 +84,7 @@ class Real_Time_Response:
         DATA = body
         PARAMS = parameters
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -98,7 +99,7 @@ class Real_Time_Response:
         DATA = body
         PARAMS = parameters
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -112,7 +113,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -129,7 +130,7 @@ class Real_Time_Response:
         DATA = body
         PARAMS = parameters
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -144,7 +145,7 @@ class Real_Time_Response:
         DATA = body
         PARAMS = parameters
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -159,7 +160,7 @@ class Real_Time_Response:
         DATA = body
         PARAMS = parameters
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -173,7 +174,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -187,7 +188,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -201,7 +202,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -215,7 +216,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -229,7 +230,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             if response.headers.get('content-type') == "application/json":
                 returned = self.Result()(response.status_code, response.headers, response.json())
             else:
@@ -246,7 +247,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -261,7 +262,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -275,7 +276,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -289,7 +290,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -303,7 +304,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -317,7 +318,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -331,7 +332,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -345,7 +346,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -359,7 +360,7 @@ class Real_Time_Response:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/real_time_response_admin.py
+++ b/src/falconpy/real_time_response_admin.py
@@ -40,12 +40,13 @@ class Real_Time_Response_Admin:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -69,7 +70,7 @@ class Real_Time_Response_Admin:
         DATA = body
         PARAMS = parameters
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -83,7 +84,7 @@ class Real_Time_Response_Admin:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -97,7 +98,7 @@ class Real_Time_Response_Admin:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -111,7 +112,7 @@ class Real_Time_Response_Admin:
         FULL_URL = self.base_url+'/real-time-response/entities/put-files/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -127,7 +128,7 @@ class Real_Time_Response_Admin:
         DATA = data
         FILES = files
         try:
-            response = requests.request("POST", FULL_URL, data=DATA, files=FILES, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, data=DATA, files=FILES, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -141,7 +142,7 @@ class Real_Time_Response_Admin:
         FULL_URL = self.base_url+'/real-time-response/entities/put-files/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -155,7 +156,7 @@ class Real_Time_Response_Admin:
         FULL_URL = self.base_url+'/real-time-response/entities/scripts/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -171,7 +172,7 @@ class Real_Time_Response_Admin:
         DATA = data
         FILES = files
         try:
-            response = requests.request("POST", FULL_URL, data=DATA, files=FILES, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, data=DATA, files=FILES, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -185,7 +186,7 @@ class Real_Time_Response_Admin:
         FULL_URL = self.base_url+'/real-time-response/entities/scripts/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -201,7 +202,7 @@ class Real_Time_Response_Admin:
         DATA = data
         FILES = files
         try:
-            response = requests.request("PATCH", FULL_URL, data=DATA, files=FILES, headers=HEADERS, verify=False)
+            response = requests.request("PATCH", FULL_URL, data=DATA, files=FILES, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -215,7 +216,7 @@ class Real_Time_Response_Admin:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -229,7 +230,7 @@ class Real_Time_Response_Admin:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/sensor_update_policy.py
+++ b/src/falconpy/sensor_update_policy.py
@@ -40,12 +40,13 @@ class Sensor_Update_Policy:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -68,7 +69,7 @@ class Sensor_Update_Policy:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -84,7 +85,7 @@ class Sensor_Update_Policy:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -100,7 +101,7 @@ class Sensor_Update_Policy:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -116,7 +117,7 @@ class Sensor_Update_Policy:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -132,7 +133,7 @@ class Sensor_Update_Policy:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -147,7 +148,7 @@ class Sensor_Update_Policy:
         DATA = body
         PARAMS = parameters
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -164,7 +165,7 @@ class Sensor_Update_Policy:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -178,7 +179,7 @@ class Sensor_Update_Policy:
         FULL_URL = self.base_url+'/policy/entities/sensor-update/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -192,7 +193,7 @@ class Sensor_Update_Policy:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -206,7 +207,7 @@ class Sensor_Update_Policy:
         FULL_URL = self.base_url+'/policy/entities/sensor-update/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -220,7 +221,7 @@ class Sensor_Update_Policy:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("PATCH", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("PATCH", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -234,7 +235,7 @@ class Sensor_Update_Policy:
         FULL_URL = self.base_url+'/policy/entities/sensor-update/v2?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -248,7 +249,7 @@ class Sensor_Update_Policy:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -262,7 +263,7 @@ class Sensor_Update_Policy:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("PATCH", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("PATCH", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -278,7 +279,7 @@ class Sensor_Update_Policy:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -294,7 +295,7 @@ class Sensor_Update_Policy:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/spotlight_vulnerabilities.py
+++ b/src/falconpy/spotlight_vulnerabilities.py
@@ -40,12 +40,13 @@ class Spotlight_Vulnerabilities:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -68,7 +69,7 @@ class Spotlight_Vulnerabilities:
         FULL_URL = self.base_url+'/spotlight/entities/vulnerabilities/v2?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -84,7 +85,7 @@ class Spotlight_Vulnerabilities:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/src/falconpy/user_management.py
+++ b/src/falconpy/user_management.py
@@ -40,12 +40,13 @@ class User_Management:
         is a valid token provided by the Falcon API SDK OAuth2 class.
     """
 
-    def __init__(self, access_token, base_url='https://api.crowdstrike.com'):
+    def __init__(self, access_token, base_url='https://api.crowdstrike.com', ssl_verify=True):
         """ Instantiates the base class, ingests the authorization token, 
             and initializes the headers and base_url global variables. 
         """
         self.headers = { 'Authorization': 'Bearer {}'.format(access_token) }
         self.base_url = base_url
+        self.ssl_verify = ssl_verify
 
     class Result:
         """ Subclass to handle parsing of result client output. """
@@ -68,7 +69,7 @@ class User_Management:
         FULL_URL = self.base_url+'/user-roles/entities/user-roles/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -83,7 +84,7 @@ class User_Management:
         DATA = body
         PARAMS = parameters
         try:
-            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -98,7 +99,7 @@ class User_Management:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -113,7 +114,7 @@ class User_Management:
         FULL_URL = self.base_url+'/user-roles/queries/user-role-ids-by-cid/v1'
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -127,7 +128,7 @@ class User_Management:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -141,7 +142,7 @@ class User_Management:
         FULL_URL = self.base_url+'/users/entities/users/v1?ids={}'.format(ID_LIST)
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -155,7 +156,7 @@ class User_Management:
         HEADERS = self.headers
         DATA = body
         try:
-            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("POST", FULL_URL, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -169,7 +170,7 @@ class User_Management:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("DELETE", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -184,7 +185,7 @@ class User_Management:
         DATA = body
         PARAMS = parameters
         try:
-            response = requests.request("PATCH", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=False)
+            response = requests.request("PATCH", FULL_URL, params=PARAMS, json=DATA, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -197,7 +198,7 @@ class User_Management:
         FULL_URL = self.base_url+'/users/queries/emails-by-cid/v1'
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -210,7 +211,7 @@ class User_Management:
         FULL_URL = self.base_url+'/users/queries/user-uuids-by-cid/v1'
         HEADERS = self.headers
         try:
-            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))
@@ -224,7 +225,7 @@ class User_Management:
         HEADERS = self.headers
         PARAMS = parameters
         try:
-            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=False)
+            response = requests.request("GET", FULL_URL, params=PARAMS, headers=HEADERS, verify=self.ssl_verify)
             returned = self.Result()(response.status_code, response.headers, response.json())
         except Exception as e:
             returned = self.Result()(500, {}, str(e))

--- a/tests/test_uber_api_complete.py
+++ b/tests/test_uber_api_complete.py
@@ -11,6 +11,9 @@ import hashlib
 sys.path.append(os.path.abspath('src'))
 # Classes to test - manually imported from our sibling folder
 from falconpy import api_complete as FalconSDK
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
+urllib3.disable_warnings(InsecureRequestWarning)
 
 AllowedResponses = [200, 400, 415, 429, 500] 
 
@@ -156,6 +159,17 @@ class TestUber:
         else:
             return False 
         
+    def uberCCAWS_DisableSSLVerify(self):
+        falcon = FalconSDK.APIHarness(
+            creds={
+                "client_id": config["falcon_client_id"],
+                "client_secret": config["falcon_client_secret"]
+            }, ssl_verify=False
+        )
+        if falcon.command("QueryAWSAccounts", parameters={"limit":1})["status_code"] in AllowedResponses:
+            return True
+        else:
+            return False 
 
     def test_GetAWSSettings(self):
         assert self.uberCCAWS_GetAWSSettings() == True
@@ -202,3 +216,7 @@ class TestUber:
 
     def test_BadAuthentication(self):
         assert self.uberCCAWS_BadAuthentication() == True
+
+    @pytest.mark.filterwarnings("ignore:Unverified HTTPS request is being made.*")
+    def test_DisableSSLVerify(self):
+        assert self.uberCCAWS_DisableSSLVerify() == True


### PR DESCRIPTION
This PR implements the following:
- Updates the Uber class to support user-specified SSL verification for calls using the requests library
    - This parameter is now defaulted to __True__ 
- Updates all Service classes to support user-specified SSL verification for calls using the requests library
    - This parameter is now defaulted to __True__ 
- Enables warnings for PyTest unit testing
- Adds a new unit test to test disabling SSL verification (Uber class unit test)
- Disables Python 3.5 unit testing

>**Potential Breaking Change** for developers in environments where certificate pinning could be impacted by intermediary network hardware or policies. 

Since the default value for SSL verification is moving from _False_ to _True_ in this release, there are some customers who may need to disable this functionality. 

This can be done programmatically when you instantiate an instance of the class as follows:
```python
falcon = FalconSDK.APIHarness(
    creds={
        "client_id": falcon_client_id,
        "client_secret": falcon_client_secret
    }, 
    ssl_verify=False
)
```

A test package has been uploaded to allow developers to test these changes:
```bash
pip install -i https://test.pypi.org/simple/ crowdstrike-falconpy
```

or

```bash
python3 -m pip pip install -i https://test.pypi.org/simple/ crowdstrike-falconpy
```

Production PyPI package release date: **02.15.2021**