### PR TITLE
Fixed: Typo in Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Contributor Covenant Code of Conduct
+# FalconPy Community Code of Conduct
 
 ## Our Pledge
 


### PR DESCRIPTION
## Typo: Code of Conduct title
This PR resolves a typo in the Code of Conduct
- [x] Documentation

```shell
SOURCE PACKAGE NOT IMPACTED BY THIS CHANGE
```
## Issues resolved
+ Typo: Title error in Code of Conduct
