### PR TITLE
Create dev-deploy.yml

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -1,0 +1,33 @@
+name: Test Package Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy-package:
+
+    runs-on: ubuntu-latest
+    if: "startsWith(github.event.head_commit.message, '[DEPLOY]')"
+
+    steps:
+
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build and publish to test index
+      env:
+        TWINE_USERNAME: ${{ secrets.DEV_PACKAGE_ID }}
+        TWINE_PASSWORD: ${{ secrets.DEV_PACKAGE_SECRET }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload --repository testpypi dist/*


### PR DESCRIPTION
## Add test package deployment to targeted PR merges
This workflow will build and publish the package to TestPyPI upon successful merge of a PR to main. This workflow is only triggered if the first characters in the head of the commit are `[DEPLOY]`.

> At this point in time, maintainers are still responsible for incrementing package versions.

- [x] Enhancement

#### Unit test coverage
```shell
NOT REQUIRED
```

#### Bandit analysis
```shell
NOT REQUIRED
```

## Issues resolved
+ Added: Development package publishing workflow, Closes #12 
