### PR TITLE
Enabling Proxy for CrowdStrike Falcon

### DIFF
--- a/src/falconpy/_util.py
+++ b/src/falconpy/_util.py
@@ -112,6 +112,7 @@ def service_request(caller: object = None, **kwargs) -> object:  # May return di
             pass
 
     returned = perform_request(**kwargs)
+    print(returned)
 
     return returned
 
@@ -120,7 +121,8 @@ def perform_request(method: str = "", endpoint: str = "", headers: dict = None,
                     params: dict = None, body: dict = None, verify: bool = True,
                     data=None, files: list = None,
                     params_validator: dict = None, params_required: dict = None,
-                    body_validator: dict = None, body_required: dict = None) -> object:  # May return dict or object datatypes
+                    body_validator: dict = None, body_required: dict = None,
+                    proxy: dict = None) -> object:  # May return dict or object datatypes
     """
         Leverages the requests library to perform the requested CrowdStrike OAuth2 API operation.
 
@@ -180,8 +182,12 @@ def perform_request(method: str = "", endpoint: str = "", headers: dict = None,
         if PERFORM:
             headers["User-Agent"] = _USER_AGENT  # Force all requests to pass the User-Agent identifier
             try:
-                response = requests.request(METHOD, endpoint, params=params, headers=headers,
-                                            json=body, data=data, files=files, verify=verify)
+                if proxy:
+                    response = requests.request(METHOD, endpoint, params=params, headers=headers,
+                                                json=body, data=data, files=files, verify=verify, proxies=proxy)
+                else:
+                    response = requests.request(METHOD, endpoint, params=params, headers=headers,
+                                                json=body, data=data, files=files, verify=verify)
                 if response.headers.get('content-type') == "application/json":
                     returned = Result()(response.status_code, response.headers, response.json())
                 else:

--- a/src/falconpy/_util.py
+++ b/src/falconpy/_util.py
@@ -112,7 +112,6 @@ def service_request(caller: object = None, **kwargs) -> object:  # May return di
             pass
 
     returned = perform_request(**kwargs)
-    print(returned)
 
     return returned
 

--- a/src/falconpy/api_complete.py
+++ b/src/falconpy/api_complete.py
@@ -50,13 +50,14 @@ class APIHarness:
     TOKEN_RENEW_WINDOW = 20  # in seconds
 
     def __init__(self: object, creds: dict, base_url: str = "https://api.crowdstrike.com",
-                 ssl_verify: bool = True) -> object:
+                 ssl_verify: bool = True, proxy: dict = None) -> object:
         """Instantiates an instance of the base class, ingests credentials, the base URL and the SSL verification
            boolean. Afterwards class attributes are initialized.
         """
         self.creds = creds
         self.base_url = base_url
         self.ssl_verify = ssl_verify
+        self.proxy = proxy
         self.token = False
         self.token_expiration = 0
         self.token_time = time.time()
@@ -92,7 +93,7 @@ class APIHarness:
         if "member_cid" in self.creds:
             data_payload["member_cid"] = self.creds["member_cid"]
 
-        result = perform_request(method="POST", endpoint=target, data=data_payload, headers={}, verify=self.ssl_verify)
+        result = perform_request(method="POST", endpoint=target, data=data_payload, headers={}, verify=self.ssl_verify, proxy=self.proxy)
         if result["status_code"] == 201:
             self.token = result["body"]["access_token"]
             self.token_expiration = result["body"]["expires_in"]
@@ -112,7 +113,7 @@ class APIHarness:
         data_payload = {'token': '{}'.format(self.token)}
         revoked = False
         if perform_request(method="POST", endpoint=target, data=data_payload,
-                           headers=header_payload, verify=self.ssl_verify)["status_code"] == 200:
+                           headers=header_payload, verify=self.ssl_verify, proxy=self.proxy)["status_code"] == 200:
             self.authenticated = False
             self.token = False
             revoked = True
@@ -197,7 +198,8 @@ class APIHarness:
                                                params=parameter_payload,
                                                headers=header_payload,
                                                files=file_list,
-                                               verify=self.ssl_verify
+                                               verify=self.ssl_verify,
+                                               proxy=self.proxy
                                                )
                 else:
                     # Bad HTTP method

--- a/src/falconpy/oauth2.py
+++ b/src/falconpy/oauth2.py
@@ -51,11 +51,13 @@ class OAuth2:
         }
     """
 
-    def __init__(self: object, creds: dict, base_url: str = "https://api.crowdstrike.com", ssl_verify: bool = True):
+    def __init__(self: object, creds: dict, base_url: str = "https://api.crowdstrike.com",
+                 ssl_verify: bool = True, proxy: dict = None):
         """ Initializes the base class by ingesting credentials, the base URL, and SSL verification options. """
         self.creds = creds
         self.base_url = base_url
         self.ssl_verify = ssl_verify
+        self.proxy = proxy
         self.token_expiration = 0
         self.token_renew_window = 20
         self.token_time = time.time()
@@ -69,6 +71,7 @@ class OAuth2:
         self.authenticated = lambda: False if self.token_expired() else True
 
     def token(self: object) -> dict:
+        print(self)
         """ Generates an authorization token. """
         FULL_URL = self.base_url+'/oauth2/token'
         HEADERS = {}
@@ -78,7 +81,8 @@ class OAuth2:
         }
         if "member_cid" in self.creds:
             DATA["member_cid"] = self.creds["member_cid"]
-        returned = perform_request(method="POST", endpoint=FULL_URL, data=DATA, headers=HEADERS, verify=self.ssl_verify)
+        returned = perform_request(method="POST", endpoint=FULL_URL, data=DATA, headers=HEADERS,
+                                   verify=self.ssl_verify, proxy=self.proxy)
         if returned["status_code"] == 201:
             self.token_expiration = returned["body"]["expires_in"]
             self.token_time = time.time()
@@ -91,7 +95,8 @@ class OAuth2:
         FULL_URL = self.base_url+'/oauth2/revoke'
         HEADERS = {'Authorization': 'basic {}'.format(generate_b64cred(self.creds["client_id"], self.creds["client_secret"]))}
         DATA = {'token': '{}'.format(token)}
-        returned = perform_request(method="POST", endpoint=FULL_URL, data=DATA, headers=HEADERS, verify=self.ssl_verify)
+        returned = perform_request(method="POST", endpoint=FULL_URL, data=DATA, headers=HEADERS,
+                                   verify=self.ssl_verify, proxy=self.proxy)
         self.token_expiration = 0
         self.token_value = False
 


### PR DESCRIPTION
## Enabling Proxy for CrowdStrike Falcon
I have added in a capability to specify a proxy for Falcon API calls. The code utilizes the proxy functionality in the requests library. 
A  user can specify a proxy in a dict like so:

`proxies = {"http": "http://myrandomproxy.com:8080",
                  "https": "http://myrandomproxy.com:8080"}`

And pass it in as an argument wherever a request to the API is made

`authorization = FalconAuth.OAuth2(creds={"client_id": "someIDhere",
                                                                      "client_secret": "somePasswordHere",},
                                                                       base_url="https://mybaseurl.com", 
                                                                       proxy=self.proxies)`


- [X] Enhancement
- [ ] Major Feature update
- [ ] Bug fixes 
- [ ] Breaking Change
- [ ] Updated unit tests
- [ ] Documentation

#### Unit test coverage
```shell
PENDING
```

#### Bandit analysis
```shell
PENDING
```

## Added features and functionality
Added proxy capability, allowing proxy to be specified for any requests library call.