### PR TITLE
[DEPLOY] v0.5.7 - Bug fixes, Service Class updates, Unit test refactoring

### DIFF
--- a/.github/workflows/unit_testing_macos.yml
+++ b/.github/workflows/unit_testing_macos.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         # os: [macos-latest, windows-latest, ubuntu-latest]
-        # python-version: ['3.6', '3.7', '3.8', '3.9']
-        python-version: ['3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
+        # python-version: ['3.9']
     # runs-on: ${{ matrix.os }}
     runs-on: macos-latest
     steps:

--- a/.github/workflows/unit_testing_macos.yml
+++ b/.github/workflows/unit_testing_macos.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         # os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
-        # python-version: ['3.9']
+        # python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.9']
     # runs-on: ${{ matrix.os }}
     runs-on: macos-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,129 @@
+# Version 0.5.7
+## Added features and functionality
++ Refactored Sample Uploads Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #255. `sample_uploads.py`
++ Refactored Real Time Response Admin Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #256. `real_time_response_admin.py`
++ Refactored Firewall Management Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #257. `firewall_management.py`
++ Refactored Custom IOA Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #258. `custom_ioa.py`
++ Refactored Falcon X Sandbox Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #259. `falconx_sandbox.py`
++ Refactored Zero Trust Assessment Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #260. `zero_trust_assessment.py`
++ Refactored Events Streams Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #248. `event_streams.py`
+
+## Issues resolved
++ Bug fix: Resolved HTTP status code 415 on calls to refreshActiveStreamSession (refresh_active_stream). Closes #247. `event_streams.py`
++ Bug fix: Resolved header pollution issue within Falcon X Sandbox Service Class. Closes #250. `falconx_sandbox.py`
++ Bug fix: Resolved header pollution issue within Firewall Management Service Class. Closes #252. `firewall_management.py`
++ Bug fix: Resolved header pollution issue within Custom IOA Service Class. Closes #253. `custom_ioa.py`
++ Bug fix: Resolved header pollution issue within Sample Uploads Service Class. Closes #254. `sample_uploads.py`
++ Bug fix: Resolved HTTP status code 500 error on calls to RTR_CreatePut_Files (create_put_files). Closes #261. `real_time_response_admin.py`
++ Bug fix: Resolved HTTP status code 400 or 500 error on calls to RTR_UpdateScripts (update_scripts) and calls to RTR_CreateScripts (create_scripts). Closes #262. `real_time_response_admin.py`
++ Bug fix: Updated force_default helper function to drop all but the first argument passed to the method, forcing Service Classes to support keywords only. Closes #263. `_util.py`
+> Potential __*breaking change*__: Developers must use keywords, __not arguments__, when specifying parameters provided to Service Class methods.
+#### Example
+```python
+from falconpy.hosts import Hosts
+falcon = Hosts(creds={"client_id": CLIENT_ID_HERE, "client_secret": CLIENT_SECRET_HERE})
+
+result = falcon.GetDeviceDetails(ids="12345"))   # This command will work
+print(result)
+
+bad_result = falcon.GetDeviceDetails("12345")    # This command will fail with the API complaining
+print(bad_result)                                # that the "ids" parameter is not present.
+```
+
++ Related to #263: Updated Uber class to no longer leverage the force_default helper, allowing users to still use the first argument to specify the action to be performed. `api_complete.py`
+> Note: This functionality _only_ works when using the Uber class, and _only_ with the __action__ parameter.
+
+## Other
++ Initial refactoring of unit test harnesses for service classes detailed above.
+    - `test_cloud_connect_aws.py`
+    - `test_custom_ioa.py`
+    - `test_event_streams.py`
+    - `test_falconx_sandbox.py`
+    - `test_firewall_management.py`
+    - `test_real_time_response_admin.py` (Updated to cover additional API operations)
+    - `test_sample_uploads.py`
+    - `zero_trust_assessment.py`
++ Minor adjustment to Uber class unit tests to better demonstrate proper method usage. `test_uber_api_complete.py`
++ Initial refactoring of unit tests to support US-2 / Gov base URL testing.
+    - `test_authorization.py`
+
+# Version 0.5.6
+## Added features and functionality
++ Added: New functionality for handling service class modules within FalconDebug.
+
+## Issues resolved
++ Bug fix: Resolved JSONDecode error on RTR_DeleteSession. Closes #238.
++ Bug fix: Resolved issue with credential authentication in service classes not respecting custom API configuration attributes. Closes #242. 
+
+## Other
++ Package metadata updates
++ Updated IDP unit tests to more accurately cover functionality
++ Flaky unit test adjustments
++ FalconDebug added to linting workflows `debug.py`
+
+# Version 0.5.5
+## Added features and functionality
++ Refactored Custom IOA Service Class to the new pattern to provide for new parameter handling functionality, closes #217. `custom_ioa.py`
++ Refactored Device Control Policies Service Class to the new pattern to provide for new parameter handling functionality, closes #224. `device_control_policies.py`
++ Refactored Firewall Policies Service Class to the new pattern to provide for new parameter handling functionality, closes #227. `firewall_policies.py`
++ Refactored Firewall Management Service Class to match the most recent pattern, closes #232. `firewall_management.py`
++ Refactored Falcon X Sandbox Service Class to the new pattern to provide for new parameter handling functionality, closes #226. `falconx_sandbox.py`
++ Refactored Hosts Service Class to the new pattern to provide for new parameter handling functionality, closes #218. `hosts.py`
++ Refactored Host Group Service Class to the new pattern to provide for new parameter handling functionality, closes #223. `host_group.py`
++ Refactored Intel Service Class to match the most recent pattern, closes #231. `intel.py`
++ Refactored OAuth2 class to reflect new functionality and linting patterns, closes #233. `oauth2.py`
++ Refactored Quick Scan Service Class to match the most recent pattern, closes #219. `quick_scan.py`
++ Refactored Real Time Response Service Class to match the most recent pattern, closes #230. `real_time_response.py`
++ Refactored Real Time Response Admin Service Class to match the most recent pattern, closes #229. `real_time_response_admin.py`
++ Refactored Sensor Updated Policy Service Class to the new pattern to provide for new parameter handling functionality, closes #222. `sensor_update_policy.py`
++ Refactored Sensor Downloads Service Class to the new pattern to provide for new parameter handling functionality, closes #221. `sensor_downloads.py`
++ Refactored Sample Uploads Service Class to the new pattern to provide for new parameter handling functionality, closes #220. `sample_uploads.py`
++ Refactored User Management Service Class to match the most recent pattern, closes #228. `user_management.py`
+
+## Issues resolved
++ Bug fix: Resolved issue with the timeout parameter not being passed to the OAuth2 class when legacy authentication was being used. Closes #225.
+
+## Other
++ Enabled Pylint stopping the build on linting failures within package source.
++ Unit test updates to expand code coverage for new code paths.
++ This update provides part of the functionality requested in #115.
+
+# Version 0.5.4
+## Added features and functionality
++ Added `identity_protection.py` - Identity Protection service class.
++ Added utility to create a zip archive to be used with AWS Lambda layers. (`create-lambda-layer.sh`)
+
+## Issues resolved
++ Bug fix: Resolved order of operations issue with body validation in __validate_payload__ helper function. (`_util.py`)
++ Updated `cloud_connect_aws.py` - Cloud_Connect_AWS Service Class. Closes #209.
++ Updated `detects.py` - Detects Service Class. Closes #210.
++ Updated `event_streams.py` - Event Streams Service Class. Closes #212.
++ Updated `incidents.py` - Incidents Service Class. Closes #213.
++ Updated `spotlight_vulnerabilities.py` - Spotlight Vulnerabilities Service Class. Closes #214.
++ Updated `zero_trust_assessment.py` - Zero Trust Assessment Service Class. Closes #211.
++ Updated query used for unit testing of Spotlight Vulnerabilities service class. 2020 -> 2021 (`test_spotlight_vulnerabilities.py`)
++ Bug fix: Resolved flaky unit test for RegenerateAPIKey for Kubernetes Protection service class. (`test_kubernetes_protection.py`).
+
+## Other
++ Added pylint workflow to push / pull_request actions.
++ _endpoint module updates to support new service class.
++ Added unit testing for new service class.
++ Unit testing updates to complete code coverage.
++ README.md updated.
++ Added additional classifers and developer requirements to PIP package metadata. (`setup.py`)
+
+# Version 0.5.3
+## Issues resolved
++ Bug fix: Resolves #200 by moving the failing method (entities_processes) in `iocs.py` to the latest code pattern.
+
+# Version 0.5.2
+## Issues resolved
++ Fixed: Incorrect endpoint specified in the updateSensorUpdatePoliciesV2 method within the Sensor Update Policy service class.
+
+# Version 0.5.1
+## Issues resolved
++ Fixed: https://github.com/CrowdStrike/falconpy/issues/181 by adding the parameters to the create and update ioc functions.
+
 # Version 0.5.0
 ## Added features and functionality
 + Added: IOC API Service Class (`ioc.py`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Version 0.5.7
 ## Added features and functionality
-+ Refactored Sample Uploads Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #255. `sample_uploads.py`
-+ Refactored Real Time Response Admin Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #256. `real_time_response_admin.py`
-+ Refactored Firewall Management Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #257. `firewall_management.py`
++ Refactored Events Streams Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #248. `event_streams.py`
 + Refactored Custom IOA Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #258. `custom_ioa.py`
 + Refactored Falcon X Sandbox Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #259. `falconx_sandbox.py`
++ Refactored Firewall Management Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #257. `firewall_management.py`
++ Refactored Intel Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #264. `intel.py`
++ Refactored Real Time Response Admin Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #256. `real_time_response_admin.py`
++ Refactored Sample Uploads Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #255. `sample_uploads.py`
 + Refactored Zero Trust Assessment Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #260. `zero_trust_assessment.py`
-+ Refactored Events Streams Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #248. `event_streams.py`
 
 ## Issues resolved
 + Bug fix: Resolved HTTP status code 415 on calls to refreshActiveStreamSession (refresh_active_stream). Closes #247. `event_streams.py`
@@ -39,6 +40,7 @@ print(bad_result)                                # that the "ids" parameter is n
     - `test_custom_ioa.py`
     - `test_event_streams.py`
     - `test_falconx_sandbox.py`
+    - `test_intel.py`
     - `test_firewall_management.py`
     - `test_real_time_response_admin.py` (Updated to cover additional API operations)
     - `test_sample_uploads.py`

--- a/src/falconpy/_util.py
+++ b/src/falconpy/_util.py
@@ -356,10 +356,14 @@ def process_service_request(calling_object: object,
         body: Dictionary representing the body payload passed to the service class function.
         data: Dictionary representing the data payload passed to the service class function.
         files: List of files to be uploaded.
+        partition: ID of the partition to open (Event Streams API)
     """
     # ID replacement happening at the end of this statement planned for removal in v0.5.6+
     # (after all classes have been updated to no longer need it and it has been removed from the _endpoints module)
     target_url = f"{calling_object.base_url}{[ep[2] for ep in endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
+    passed_partition = kwargs.get("partition", None)
+    if passed_partition:
+        target_url = target_url.format(str(passed_partition))
     # Retrieve our keyword arguments
     passed_keywords = kwargs.get("keywords", None)
     passed_params = kwargs.get("params", None)

--- a/src/falconpy/_util.py
+++ b/src/falconpy/_util.py
@@ -141,6 +141,9 @@ def force_default(defaults: list, default_types: list = None):
                     kwargs[element] = get_default(default_types, element_count)
                 # Increment our tracker for our sibling default_types list
                 element_count += 1
+            # The passed us an argument but did not specify what it was (non-keyword) [Issue #263]
+            if len(args) > 1:
+                args = args[:-1]
             return func(*args, **kwargs)
         return factory
     return wrapper

--- a/src/falconpy/_util.py
+++ b/src/falconpy/_util.py
@@ -143,7 +143,7 @@ def force_default(defaults: list, default_types: list = None):
                 element_count += 1
             # The passed us an argument but did not specify what it was (non-keyword) [Issue #263]
             if len(args) > 1:
-                args = args[:-1]
+                args = [args[0]]
             return func(*args, **kwargs)
         return factory
     return wrapper

--- a/src/falconpy/_version.py
+++ b/src/falconpy/_version.py
@@ -36,7 +36,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
-_VERSION = '0.5.6'
+_VERSION = '0.5.7'
 _MAINTAINER = 'Joshua Hiller'
 _AUTHOR = 'CrowdStrike'
 _AUTHOR_EMAIL = 'falconpy@crowdstrike.com'

--- a/src/falconpy/custom_ioa.py
+++ b/src/falconpy/custom_ioa.py
@@ -36,13 +36,13 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
-# pylint: disable=C0103  # Aligning method names to API operation IDs
-from ._util import service_request, parse_id_list, force_default, args_to_params
+import json
+from ._util import parse_id_list, force_default, process_service_request
 from ._service_class import ServiceClass
 from ._endpoint._custom_ioa import _custom_ioa_endpoints as Endpoints
 
 
-class Custom_IOA(ServiceClass):
+class CustomIOA(ServiceClass):
     """
     The only requirement to instantiate an instance of this class
     is a valid token provided by the Falcon API SDK OAuth2 class.
@@ -53,122 +53,97 @@ class Custom_IOA(ServiceClass):
         Get pattern severities by ID
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/get-patterns
-        operation_id = "get_patterns"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="get_patterns",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def get_platformsMixin0(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_platforms(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get platforms by ID
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/get-platformsMixin0
-        operation_id = "get_platformsMixin0"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="get_platformsMixin0",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def get_rule_groupsMixin0(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_rule_groups(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get rule groups by ID
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/get-rule-groupsMixin0
-        operation_id = "get_rule_groupsMixin0"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="get_rule_groupsMixin0",
+            keywords=kwargs,
+            params=parameters
+            )
 
-    def create_rule_groupMixin0(self: object, body: dict, cs_username: str) -> dict:
+    def create_rule_group(self: object, body: dict, cs_username: str) -> dict:
         """
         Create a rule group for a platform with a name and an optional description. Returns the rule group.
         """
         # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/create-rule-groupMixin0
-        operation_id = "create_rule_groupMixin0"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our X-CS-USERNAME header
         header_payload["X-CS-USERNAME"] = cs_username
-        body_payload = body
-        returned = service_request(caller=self,
-                                   method="POST",
-                                   endpoint=target_url,
-                                   body=body_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="POST",
+            operation_id="create_rule_groupMixin0",
+            body=body,
+            headers=header_payload
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def delete_rule_groupMixin0(self: object, *args, **kwargs) -> dict:
-        """
-        Delete rule groups by ID. (Redirects to actual method. Typo fix.)
-        """
-        returned = self.delete_rule_groupsMixin0(*args, **kwargs)
-        return returned
-
-    @force_default(defaults=["parameters"], default_types=["dict"])
-    def delete_rule_groupsMixin0(self: object, cs_username: str, parameters: dict = None, **kwargs) -> dict:
+    def delete_rule_groups(self: object, cs_username: str, parameters: dict = None, **kwargs) -> dict:
         """
         Delete rule groups by ID.
         """
         # [DELETE] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/delete-rule-groupsMixin0
-        operation_id = "delete_rule_groupsMixin0"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our X-CS-USERNAME header
         header_payload["X-CS-USERNAME"] = cs_username
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="DELETE",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="DELETE",
+            operation_id="delete_rule_groupsMixin0",
+            keywords=kwargs,
+            params=parameters,
+            headers=header_payload
+            )
 
-    def update_rule_groupMixin0(self: object, body: dict, cs_username: str) -> dict:
+    def update_rule_group(self: object, body: dict, cs_username: str) -> dict:
         """
         Update a rule group. The following properties can be modified: name, description, enabled.
         """
         # [PATCH] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/update-rule-groupMixin0
-        operation_id = "update_rule_groupMixin0"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our X-CS-USERNAME header
         header_payload["X-CS-USERNAME"] = cs_username
-        body_payload = body
-        returned = service_request(caller=self,
-                                   method="PATCH",
-                                   endpoint=target_url,
-                                   body=body_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="PATCH",
+            operation_id="update_rule_groupMixin0",
+            body=body,
+            headers=header_payload
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
     def get_rule_types(self: object, parameters: dict = None, **kwargs) -> dict:
@@ -176,76 +151,61 @@ class Custom_IOA(ServiceClass):
         Get rule types by ID
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/get-rule-types
-        operation_id = "get_rule_types"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="get_rule_types",
+            keywords=kwargs,
+            params=parameters
+            )
 
     def get_rules_get(self: object, ids) -> dict:
         """
         Get rules by ID and optionally version in the following format: ID[:version]
         """
         # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/get-rules-get
-        operation_id = "get_rules_get"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
         body_payload = {}
         body_payload["ids"] = parse_id_list(ids).split(",")
-        returned = service_request(caller=self,
-                                   method="POST",
-                                   endpoint=target_url,
-                                   body=body_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="POST",
+            operation_id="get_rules_get",
+            body=body_payload
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def get_rulesMixin0(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_rules(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get rules by ID and optionally version in the following format: ID[:version].
         The max number of IDs is constrained by URL size.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/get-rulesMixin0
-        operation_id = "get_rulesMixin0"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="get_rulesMixin0",
+            keywords=kwargs,
+            params=parameters
+            )
 
     def create_rule(self: object, body: dict, cs_username: str) -> dict:
         """
         Create a rule within a rule group. Returns the rule.
         """
         # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/create-rule
-        operation_id = "create_rule"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our X-CS-USERNAME header
         header_payload["X-CS-USERNAME"] = cs_username
-        body_payload = body
-        returned = service_request(caller=self,
-                                   method="POST",
-                                   endpoint=target_url,
-                                   body=body_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="POST",
+            operation_id="create_rule",
+            body=body,
+            headers=header_payload
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
     def delete_rules(self: object, cs_username: str, parameters: dict = None, **kwargs) -> dict:
@@ -253,56 +213,50 @@ class Custom_IOA(ServiceClass):
         Delete rules from a rule group by ID.
         """
         # [DELETE] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/delete-rules
-        operation_id = "delete_rules"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our X-CS-USERNAME header
         header_payload["X-CS-USERNAME"] = cs_username
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="DELETE",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="DELETE",
+            operation_id="delete_rules",
+            keywords=kwargs,
+            params=parameters,
+            headers=header_payload
+            )
 
     def update_rules(self: object, body: dict, cs_username: str) -> dict:
         """
         Update rules within a rule group. Return the updated rules.
         """
         # [PATCH] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/update-rules
-        operation_id = "update_rules"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our X-CS-USERNAME header
         header_payload["X-CS-USERNAME"] = cs_username
-        body_payload = body
-        returned = service_request(caller=self,
-                                   method="PATCH",
-                                   endpoint=target_url,
-                                   body=body_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="PATCH",
+            operation_id="update_rules",
+            body=body,
+            headers=header_payload
+            )
 
     def validate(self: object, body: dict) -> dict:
         """
         Validates field values and checks for matches if a test string is provided.
         """
         # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/validate
-        operation_id = "validate"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
-        body_payload = body
-        returned = service_request(caller=self,
-                                   method="POST",
-                                   endpoint=target_url,
-                                   body=body_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="POST",
+            operation_id="validate",
+            body=body
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
     def query_patterns(self: object, parameters: dict = None, **kwargs) -> dict:
@@ -310,37 +264,27 @@ class Custom_IOA(ServiceClass):
         Get all pattern severity IDs
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/query-patterns
-        operation_id = "query_patterns"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="query_patterns",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def query_platformsMixin0(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_platforms(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get all platform IDs.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/query-platformsMixin0
-        operation_id = "query_platformsMixin0"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="query_platforms",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
     def query_rule_groups_full(self: object, parameters: dict = None, **kwargs) -> dict:
@@ -348,37 +292,27 @@ class Custom_IOA(ServiceClass):
         Find all rule groups matching the query with optional filter.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/query-rule-groups-full
-        operation_id = "query_rule_groups_full"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="query_rule_groups_full",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def query_rule_groupsMixin0(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_rule_groups(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Finds all rule group IDs matching the query with optional filter.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/query-rule-groupsMixin0
-        operation_id = "query_rule_groupsMixin0"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="query_rule_groupsMixin0",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
     def query_rule_types(self: object, parameters: dict = None, **kwargs) -> dict:
@@ -386,34 +320,43 @@ class Custom_IOA(ServiceClass):
         Get all rule type IDs.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/query-rule-types
-        operation_id = "query_rule_types"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="query_rule_types",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def query_rulesMixin0(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_rules(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Finds all rule IDs matching the query with optional filter.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/custom-ioa/query-rulesMixin0
-        operation_id = "query_rulesMixin0"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="query_rulesMixin0",
+            keywords=kwargs,
+            params=parameters
+            )
+
+    # These method names align to the operation IDs in the API but
+    # do not conform to snake_case / PEP8 and are defined here for
+    # backwards compatibility / ease of use purposes
+    get_platformsMixin0 = get_platforms
+    get_rule_groupsMixin0 = get_rule_groups
+    create_rule_groupMixin0 = create_rule_group
+    delete_rule_groupMixin0 = delete_rule_groups  # Typo fix
+    delete_rule_groupsMixin0 = delete_rule_groups
+    update_rule_groupMixin0 = update_rule_group
+    get_rulesMixin0 = get_rules
+    query_platformsMixin0 = query_platforms
+    query_rule_groupsMixin0 = query_rule_groups
+    query_rulesMixin0 = query_rules
+
+
+# The legacy name for this class does not conform to PascalCase / PEP8
+# It is defined here for backwards compatibility purposes only.
+Custom_IOA = CustomIOA  # pylint: disable=C0103

--- a/src/falconpy/custom_ioa.py
+++ b/src/falconpy/custom_ioa.py
@@ -45,7 +45,9 @@ from ._endpoint._custom_ioa import _custom_ioa_endpoints as Endpoints
 class CustomIOA(ServiceClass):
     """
     The only requirement to instantiate an instance of this class
-    is a valid token provided by the Falcon API SDK OAuth2 class.
+    is a valid token provided by the Falcon API SDK OAuth2 class, an
+    authorization object (oauth2.py) or a credential dictionary with
+    client_id and client_secret containing valid API credentials.
     """
     @force_default(defaults=["parameters"], default_types=["dict"])
     def get_patterns(self: object, parameters: dict = None, **kwargs) -> dict:

--- a/src/falconpy/debug.py
+++ b/src/falconpy/debug.py
@@ -145,7 +145,7 @@ def import_module(module: str = None):
         if found:
             current_module = sys.modules[f"{import_location}.{module}"]
             for key in dir(current_module):
-                if isinstance(getattr(current_module, key), type) and not key == "ServiceClass":
+                if isinstance(getattr(current_module, key), type) and not key == "ServiceClass" and "_" not in key:
                     _.append(getattr(_[0], key))
                     returned_object = _[1](auth_object=AUTH_OBJECT)
                     print(f"Service Class {key} imported successfully.")

--- a/src/falconpy/event_streams.py
+++ b/src/falconpy/event_streams.py
@@ -77,7 +77,7 @@ class EventStreams(ServiceClass):
             params=parameters
             )
 
-    # These methods names do not conform to snake_case and are being phased out
+    # These method names do not conform to snake_case and are being phased out
     # They are being defined here for backwards compatibility
     refreshActiveStreamSession = refresh_active_stream    # pylint: disable=C0103
     listAvailableStreamsOAuth2 = list_available_streams   # pylint: disable=C0103

--- a/src/falconpy/event_streams.py
+++ b/src/falconpy/event_streams.py
@@ -78,12 +78,12 @@ class EventStreams(ServiceClass):
             )
 
     # These method names align to the operation IDs in the API but
-    # do not conform to snake_case / PEP8 and are being phased out
-    # They are being defined here for backwards compatibility
-    refreshActiveStreamSession = refresh_active_stream    # pylint: disable=C0103
-    listAvailableStreamsOAuth2 = list_available_streams   # pylint: disable=C0103
+    # do not conform to snake_case / PEP8 and are defined here for
+    # backwards compatibility / ease of use purposes
+    refreshActiveStreamSession = refresh_active_stream
+    listAvailableStreamsOAuth2 = list_available_streams
 
 
 # The legacy name for this class does not conform to PascalCase / PEP8
-# It is being defined here for backwards compatibility purposes only.
+# It is defined here for backwards compatibility purposes only.
 Event_Streams = EventStreams  # pylint: disable=C0103

--- a/src/falconpy/event_streams.py
+++ b/src/falconpy/event_streams.py
@@ -77,13 +77,13 @@ class EventStreams(ServiceClass):
             params=parameters
             )
 
-    # These method names do not conform to snake_case and are being phased out
+    # These method names align to the operation IDs in the API but
+    # do not conform to snake_case / PEP8 and are being phased out
     # They are being defined here for backwards compatibility
     refreshActiveStreamSession = refresh_active_stream    # pylint: disable=C0103
     listAvailableStreamsOAuth2 = list_available_streams   # pylint: disable=C0103
 
 
-# The legacy name for this class does not conform to
-# PascalCase naming style and is being phased out. It
-# is being defined here for backwards compatibility.
+# The legacy name for this class does not conform to PascalCase / PEP8
+# It is being defined here for backwards compatibility purposes only.
 Event_Streams = EventStreams  # pylint: disable=C0103

--- a/src/falconpy/event_streams.py
+++ b/src/falconpy/event_streams.py
@@ -36,51 +36,54 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
-# pylint: disable=C0103  # Aligning method names to API operation IDs
-from ._util import service_request, force_default, args_to_params
+from ._util import force_default, process_service_request
 from ._service_class import ServiceClass
 from ._endpoint._event_streams import _event_streams_endpoints as Endpoints
 
 
-class Event_Streams(ServiceClass):
+class EventStreams(ServiceClass):
     """
     The only requirement to instantiate an instance of this class
-    is a valid token provided by the Falcon API SDK OAuth2 class.
+    is a valid token provided by the Falcon API SDK OAuth2 class, an
+    authorization object (oauth2.py) or a credential dictionary with
+    client_id and client_secret containing valid API credentials.
     """
-    @force_default(defaults=["parameters"], default_types=["dict"])
-    def refreshActiveStreamSession(self: object, partition: int = 0, parameters: dict = None, **kwargs) -> dict:
+    @force_default(defaults=["parameters", "body"], default_types=["dict", "dict"])
+    def refresh_active_stream(self: object, partition: int = 0, parameters: dict = None, body: dict = None, **kwargs) -> dict:
         """
         Refresh an active event stream. Use the URL shown in a GET /sensors/entities/datafeed/v2 response.
         """
-        # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/event-streams/refreshActiveStreamSession
-        operation_id = "refreshActiveStreamSession"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("{}", str(partition))
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="POST",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="refreshActiveStreamSession",
+            method="POST",
+            body=body,  # BODY is being passed here even though it is likely empty, addresses issue #247
+            keywords=kwargs,
+            params=parameters,
+            partition=partition
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def listAvailableStreamsOAuth2(self: object, parameters: dict = None, **kwargs) -> dict:
+    def list_available_streams(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Discover all event streams in your environment.
         """
-        # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/event-streams/listAvailableStreamsOAuth2
-        operation_id = "listAvailableStreamsOAuth2"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="listAvailableStreamsOAuth2",
+            keywords=kwargs,
+            params=parameters
+            )
+
+    # These methods names do not conform to snake_case and are being phased out
+    # They are being defined here for backwards compatibility
+    refreshActiveStreamSession = refresh_active_stream    # pylint: disable=C0103
+    listAvailableStreamsOAuth2 = list_available_streams   # pylint: disable=C0103
+
+
+# The legacy name for this class does not conform to
+# PascalCase naming style and is being phased out. It
+# is being defined here for backwards compatibility.
+Event_Streams = EventStreams  # pylint: disable=C0103

--- a/src/falconpy/falconx_sandbox.py
+++ b/src/falconpy/falconx_sandbox.py
@@ -36,251 +36,222 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
-# pylint: disable=C0103  # Aligning method names to API operation IDs
-from ._util import service_request, force_default, args_to_params
+import json
+from ._util import force_default, process_service_request
 from ._service_class import ServiceClass
 from ._endpoint._falconx_sandbox import _falconx_sandbox_endpoints as Endpoints
 
 
-class FalconX_Sandbox(ServiceClass):
+class FalconXSandbox(ServiceClass):
     """
     The only requirement to instantiate an instance of this class
     is a valid token provided by the Falcon API SDK OAuth2 class.
     """
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def GetArtifacts(self: object, parameters: dict = None, **kwargs) -> object:
+    def get_artifacts(self: object, parameters: dict = None, **kwargs) -> object:
         """
         Download IOC packs, PCAP files, and other analysis artifacts.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/GetArtifacts
-        operation_id = "GetArtifacts"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our content-type header
         header_payload['Accept-Encoding'] = 'gzip'  # Force gzip compression
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="GetArtifacts",
+            keywords=kwargs,
+            params=parameters,
+            headers=header_payload
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def GetSummaryReports(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_summary_reports(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get a short summary version of a sandbox report.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/GetSummaryReports
-        operation_id = "GetSummaryReports"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="GetSummaryReports",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def GetSubmissions(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_submissions(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Check the status of a sandbox analysis. Time required for analysis varies but is usually less than 15 minutes.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/GetSubmissions
-        operation_id = "GetSubmissions"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="GetSubmissions",
+            keywords=kwargs,
+            params=parameters
+            )
 
-    def Submit(self: object, body: dict) -> dict:
+    def submit(self: object, body: dict) -> dict:
         """
         Submit an uploaded file or a URL for sandbox analysis.
         Time required for analysis varies but is usually less than 15 minutes.
         """
         # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/Submit
-        operation_id = "Submit"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
-        body_payload = body
-        returned = service_request(caller=self,
-                                   method="POST",
-                                   endpoint=target_url,
-                                   body=body_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="POST",
+            operation_id="Submit",
+            body=body
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def QueryReports(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_reports(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Find sandbox reports by providing an FQL filter and paging details.
         Returns a set of report IDs that match your criteria.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/QueryReports
-        operation_id = "QueryReports"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="QueryReports",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def QuerySubmissions(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_submissions(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Find submission IDs for uploaded files by providing an FQL filter and paging details.
         Returns a set of submission IDs that match your criteria.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/QuerySubmissions
-        operation_id = "QuerySubmissions"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="QuerySubmissions",
+            keywords=kwargs,
+            params=parameters
+            )
 
-    @force_default(defaults=["parameters"], default_types=["dict"])
-    def UploadSampleV2(self: object, body: dict, parameters: dict = None, **kwargs) -> dict:
+    @force_default(defaults=["parameters", "body"], default_types=["dict", "dict"])
+    def upload_sample(self: object, file_data: object, body: dict = None, parameters: dict = None, **kwargs) -> dict:
         """
         Upload a file for sandbox analysis. After uploading,
         use `/falconx/entities/submissions/v1` to start analyzing the file.
         """
         # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/UploadSampleV2
-        operation_id = "UploadSampleV2"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our content-type header
         header_payload["Content-Type"] = "application/octet-stream"
-        body_payload = body
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="POST",
-                                   endpoint=target_url,
-                                   body=body_payload,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="POST",
+            operation_id="UploadSampleV2",
+            body=body,
+            data=file_data,
+            params=parameters,
+            keywords=kwargs,
+            headers=header_payload
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def GetReports(self: object, parameters: dict = None, **kwargs) -> object:
+    def get_reports(self: object, parameters: dict = None, **kwargs) -> object:
         """
         Retrieves a full sandbox report.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/GetReports
-        operation_id = "GetReports"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="GetReports",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def DeleteReport(self: object, parameters: dict = None, **kwargs) -> dict:
+    def delete_report(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Delete report based on the report ID. Operation can be checked for success
         by polling for the report ID on the report-summaries endpoint.
         """
         # [DELETE] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/DeleteReport
-        operation_id = "DeleteReport"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="DELETE",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="DELETE",
+            operation_id="DeleteReport",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def GetSampleV2(self: object, parameters: dict = None, **kwargs) -> object:
+    def get_sample(self: object, parameters: dict = None, **kwargs) -> object:
         """
         Retrieves the file associated with the given ID (SHA256).
         Use the password_protected boolean to specify if you want your zip to have a password.
         """
         # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/GetSampleV2
-        operation_id = "GetSampleV2"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="GetSampleV2",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def DeleteSampleV2(self: object, parameters: dict = None, **kwargs) -> dict:
+    def delete_sample(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Removes a sample, including file, meta and submissions from the collection.
         """
         # [DELETE] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/DeleteSampleV2
-        operation_id = "DeleteSampleV2"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="DELETE",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="DELETE",
+            operation_id="DeleteSampleV2",
+            keywords=kwargs,
+            params=parameters
+            )
 
-    @force_default(defaults=["parameters"], default_types=["dict"])
-    def QuerySampleV1(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_sample(self: object, body: dict) -> dict:
         """
         Retrieves a list with sha256 of samples that exist and customer has rights to access them,
         maximum number of accepted items is 200.
         """
-        # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/DeleteSampleV2
-        operation_id = "QuerySampleV1"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="POST",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/QuerySampleV1
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="POST",
+            operation_id="QuerySampleV1",
+            body=body
+            )
+
+    # These method names align to the operation IDs in the API but
+    # do not conform to snake_case / PEP8 and are defined here for
+    # backwards compatibility / ease of use purposes
+    GetArtifacts = get_artifacts
+    GetSummaryReports = get_summary_reports
+    GetSubmissions = get_submissions
+    Submit = submit
+    QueryReports = query_reports
+    QuerySubmissions = query_submissions
+    UploadSampleV2 = upload_sample
+    GetReports = get_reports
+    DeleteReport = delete_report
+    GetSampleV2 = get_sample
+    DeleteSampleV2 = delete_sample
+    QuerySampleV1 = query_sample
+
+
+# The legacy name for this class does not conform to PascalCase / PEP8
+# It is defined here for backwards compatibility purposes only.
+FalconX_Sandbox = FalconXSandbox  # pylint: disable=C0103

--- a/src/falconpy/falconx_sandbox.py
+++ b/src/falconpy/falconx_sandbox.py
@@ -45,7 +45,9 @@ from ._endpoint._falconx_sandbox import _falconx_sandbox_endpoints as Endpoints
 class FalconXSandbox(ServiceClass):
     """
     The only requirement to instantiate an instance of this class
-    is a valid token provided by the Falcon API SDK OAuth2 class.
+    is a valid token provided by the Falcon API SDK OAuth2 class, an
+    authorization object (oauth2.py) or a credential dictionary with
+    client_id and client_secret containing valid API credentials.
     """
     @force_default(defaults=["parameters"], default_types=["dict"])
     def get_artifacts(self: object, parameters: dict = None, **kwargs) -> object:

--- a/src/falconpy/firewall_management.py
+++ b/src/falconpy/firewall_management.py
@@ -45,7 +45,9 @@ from ._endpoint._firewall_management import _firewall_management_endpoints as En
 class FirewallManagement(ServiceClass):
     """
     The only requirement to instantiate an instance of this class
-    is a valid token provided by the Falcon API SDK OAuth2 class.
+    is a valid token provided by the Falcon API SDK OAuth2 class, an
+    authorization object (oauth2.py) or a credential dictionary with
+    client_id and client_secret containing valid API credentials.
     """
     def aggregate_events(self: object, body: dict) -> dict:
         """

--- a/src/falconpy/firewall_management.py
+++ b/src/falconpy/firewall_management.py
@@ -36,13 +36,13 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
-# pylint: disable=C0103  # Aligning method names to API operation IDs
+import json
 from ._util import force_default, process_service_request
 from ._service_class import ServiceClass
 from ._endpoint._firewall_management import _firewall_management_endpoints as Endpoints
 
 
-class Firewall_Management(ServiceClass):
+class FirewallManagement(ServiceClass):
     """
     The only requirement to instantiate an instance of this class
     is a valid token provided by the Falcon API SDK OAuth2 class.
@@ -160,8 +160,10 @@ class Firewall_Management(ServiceClass):
         Update an identified policy container.
         """
         # [PUT] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/firewall-management/update_policy_container
-        header_payload = self.headers
-        header_payload['X-CS-USERNAME'] = cs_username
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our X-CS-USERNAME header
+        header_payload["X-CS-USERNAME"] = cs_username
         return process_service_request(
             calling_object=self,
             endpoints=Endpoints,
@@ -192,8 +194,10 @@ class Firewall_Management(ServiceClass):
         Create new rule group on a platform for a customer with a name and description, and return the ID.
         """
         # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/firewall-management/create_rule_group
-        header_payload = self.headers
-        header_payload['X-CS-USERNAME'] = cs_username
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our X-CS-USERNAME header
+        header_payload["X-CS-USERNAME"] = cs_username
         return process_service_request(
             calling_object=self,
             endpoints=Endpoints,
@@ -211,8 +215,10 @@ class Firewall_Management(ServiceClass):
         Delete rule group entities by ID.
         """
         # [DELETE] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/falconx-sandbox/QueryReports
-        header_payload = self.headers
-        header_payload['X-CS-USERNAME'] = cs_username
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our X-CS-USERNAME header
+        header_payload["X-CS-USERNAME"] = cs_username
         return process_service_request(
             calling_object=self,
             endpoints=Endpoints,
@@ -229,8 +235,10 @@ class Firewall_Management(ServiceClass):
         Update name, description, or enabled status of a rule group, or create, edit, delete, or reorder rules.
         """
         # [PATCH] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/firewall-management/update_rule_group
-        header_payload = self.headers
-        header_payload['X-CS-USERNAME'] = cs_username
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our X-CS-USERNAME header
+        header_payload["X-CS-USERNAME"] = cs_username
         return process_service_request(
             calling_object=self,
             endpoints=Endpoints,
@@ -339,3 +347,8 @@ class Firewall_Management(ServiceClass):
             keywords=kwargs,
             params=parameters
             )
+
+
+# The legacy name for this class does not conform to PascalCase / PEP8
+# It is defined here for backwards compatibility purposes only.
+Firewall_Management = FirewallManagement  # pylint: disable=C0103

--- a/src/falconpy/intel.py
+++ b/src/falconpy/intel.py
@@ -36,7 +36,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
-# pylint: disable=C0103  # Aligning method names to API operation IDs
 from ._util import force_default, process_service_request
 from ._service_class import ServiceClass
 from ._endpoint._intel import _intel_endpoints as Endpoints
@@ -45,10 +44,12 @@ from ._endpoint._intel import _intel_endpoints as Endpoints
 class Intel(ServiceClass):
     """
     The only requirement to instantiate an instance of this class
-    is a valid token provided by the Falcon API SDK OAuth2 class.
+    is a valid token provided by the Falcon API SDK OAuth2 class, an
+    authorization object (oauth2.py) or a credential dictionary with
+    client_id and client_secret containing valid API credentials.
     """
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def QueryIntelActorEntities(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_actor_entities(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get info about actors that match provided FQL filters.
         """
@@ -62,7 +63,7 @@ class Intel(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def QueryIntelIndicatorEntities(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_indicator_entities(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get info about indicators that match provided FQL filters.
         """
@@ -76,7 +77,7 @@ class Intel(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def QueryIntelReportEntities(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_report_entities(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get info about reports that match provided FQL filters.
         """
@@ -90,7 +91,7 @@ class Intel(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def GetIntelActorEntities(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_actor_entities(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Retrieve specific actors using their actor IDs.
         """
@@ -103,7 +104,7 @@ class Intel(ServiceClass):
             params=parameters
             )
 
-    def GetIntelIndicatorEntities(self: object, body: dict) -> dict:
+    def get_indicator_entities(self: object, body: dict) -> dict:
         """
         Retrieve specific indicators using their indicator IDs.
         """
@@ -117,7 +118,7 @@ class Intel(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def GetIntelReportPDF(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_report_pdf(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Return a Report PDF attachment.
         """
@@ -131,7 +132,7 @@ class Intel(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def GetIntelReportEntities(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_report_entities(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Retrieve specific reports using their report IDs.
         """
@@ -145,7 +146,7 @@ class Intel(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def GetIntelRuleFile(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_rule_file(self: object, parameters: dict = None, **kwargs) -> dict:
         # There is an optional header you can see Accept to choose the result format. See Swagger.
         """
         Download earlier rule sets.
@@ -160,7 +161,7 @@ class Intel(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def GetLatestIntelRuleFile(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_latest_rule_file(self: object, parameters: dict = None, **kwargs) -> dict:
         # There is an optional header you can see Accept to choose the result format. See Swagger.
         """
         Download the latest rule set.
@@ -175,7 +176,7 @@ class Intel(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def GetIntelRuleEntities(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_rule_entities(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Retrieve details for rule sets for the specified ids.
         """
@@ -189,7 +190,7 @@ class Intel(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def QueryIntelActorIds(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_actor_ids(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get actor IDs that match provided FQL filters.
         """
@@ -203,7 +204,7 @@ class Intel(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def QueryIntelIndicatorIds(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_indicator_ids(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get indicators IDs that match provided FQL filters.
         """
@@ -217,7 +218,7 @@ class Intel(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def QueryIntelReportIds(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_report_ids(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get report IDs that match provided FQL filters.
         """
@@ -231,7 +232,7 @@ class Intel(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def QueryIntelRuleIds(self: object, parameters: dict = None, **kwargs) -> dict:
+    def query_rule_ids(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Search for rule IDs that match provided filter criteria.
         """
@@ -243,3 +244,21 @@ class Intel(ServiceClass):
             keywords=kwargs,
             params=parameters
             )
+
+    # These method names align to the operation IDs in the API but
+    # do not conform to snake_case / PEP8 and are defined here for
+    # backwards compatibility / ease of use purposes
+    QueryIntelActorEntities = query_actor_entities
+    QueryIntelIndicatorEntities = query_indicator_entities
+    QueryIntelReportEntities = query_report_entities
+    GetIntelActorEntities = get_actor_entities
+    GetIntelIndicatorEntities = get_indicator_entities
+    GetIntelReportPDF = get_report_pdf
+    GetIntelReportEntities = get_report_entities
+    GetIntelRuleFile = get_rule_file
+    GetLatestIntelRuleFile = get_latest_rule_file
+    GetIntelRuleEntities = get_rule_entities
+    QueryIntelActorIds = query_actor_ids
+    QueryIntelIndicatorIds = query_indicator_ids
+    QueryIntelReportIds = query_report_ids
+    QueryIntelRuleIds = query_rule_ids

--- a/src/falconpy/real_time_response_admin.py
+++ b/src/falconpy/real_time_response_admin.py
@@ -44,7 +44,9 @@ from ._endpoint._real_time_response_admin import _real_time_response_admin_endpo
 class RealTimeResponseAdmin(ServiceClass):
     """
     The only requirement to instantiate an instance of this class
-    is a valid token provided by the Falcon API SDK OAuth2 class.
+    is a valid token provided by the Falcon API SDK OAuth2 class, an
+    authorization object (oauth2.py) or a credential dictionary with
+    client_id and client_secret containing valid API credentials.
     """
     @force_default(defaults=["parameters"], default_types=["dict"])
     def batch_admin_command(self: object, body: dict, parameters: dict = None, **kwargs) -> dict:

--- a/src/falconpy/real_time_response_admin.py
+++ b/src/falconpy/real_time_response_admin.py
@@ -149,23 +149,19 @@ class RealTimeResponseAdmin(ServiceClass):
             params=parameters
             )
 
-    def create_scripts(self: object, data, files) -> dict:
+    @force_default(defaults=["files"], default_types=["list"])
+    def create_scripts(self: object, data, files: list = None) -> dict:
         """
         Upload a new custom-script to use for the RTR `runscript` command.
         """
         # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/real-time-response-admin/RTR_CreateScripts
-        # Create a copy of our default header dictionary
-        header_payload = json.loads(json.dumps(self.headers))
-        # Set our content-type header
-        header_payload['Content-Type'] = 'multipart/form-data'
         return process_service_request(
             calling_object=self,
             endpoints=Endpoints,
             operation_id="RTR_CreateScripts",
             method="POST",
             data=data,
-            files=files,
-            headers=header_payload
+            files=files
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
@@ -188,18 +184,13 @@ class RealTimeResponseAdmin(ServiceClass):
         Upload a new scripts to replace an existing one.
         """
         # [PATCH] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/real-time-response-admin/RTR_UpdateScripts
-        # Create a copy of our default header dictionary
-        header_payload = json.loads(json.dumps(self.headers))
-        # Set our content-type header
-        header_payload['Content-Type'] = 'multipart/form-data'
         return process_service_request(
             calling_object=self,
             endpoints=Endpoints,
             operation_id="RTR_UpdateScripts",
             method="PATCH",
             data=data,
-            files=files,
-            headers=header_payload
+            files=files
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])

--- a/src/falconpy/real_time_response_admin.py
+++ b/src/falconpy/real_time_response_admin.py
@@ -36,7 +36,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
-import json
 from ._util import force_default, process_service_request
 from ._service_class import ServiceClass
 from ._endpoint._real_time_response_admin import _real_time_response_admin_endpoints as Endpoints

--- a/src/falconpy/real_time_response_admin.py
+++ b/src/falconpy/real_time_response_admin.py
@@ -106,23 +106,18 @@ class RealTimeResponseAdmin(ServiceClass):
             params=parameters
             )
 
-    def create_put_files(self: object, data, files) -> dict:
+    def create_put_files(self: object, data: dict, files: list) -> dict:
         """
         Upload a new put-file to use for the RTR `put` command.
         """
         # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/real-time-response-admin/RTR_CreatePut_Files
-        # Create a copy of our default header dictionary
-        header_payload = json.loads(json.dumps(self.headers))
-        # Set our content-type header
-        header_payload['Content-Type'] = 'multipart/form-data'
         return process_service_request(
             calling_object=self,
             endpoints=Endpoints,
             operation_id="RTR_CreatePut_Files",
             method="POST",
             data=data,
-            files=files,
-            headers=header_payload
+            files=files
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])

--- a/src/falconpy/real_time_response_admin.py
+++ b/src/falconpy/real_time_response_admin.py
@@ -36,19 +36,19 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
-# pylint: disable=C0103  # Aligning method names to API operation IDs
+import json
 from ._util import force_default, process_service_request
 from ._service_class import ServiceClass
 from ._endpoint._real_time_response_admin import _real_time_response_admin_endpoints as Endpoints
 
 
-class Real_Time_Response_Admin(ServiceClass):
+class RealTimeResponseAdmin(ServiceClass):
     """
     The only requirement to instantiate an instance of this class
     is a valid token provided by the Falcon API SDK OAuth2 class.
     """
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def BatchAdminCmd(self: object, body: dict, parameters: dict = None, **kwargs) -> dict:
+    def batch_admin_command(self: object, body: dict, parameters: dict = None, **kwargs) -> dict:
         """
         Batch executes a RTR administrator command across the hosts mapped to the given batch ID.
         """
@@ -64,7 +64,7 @@ class Real_Time_Response_Admin(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def RTR_CheckAdminCommandStatus(self: object, parameters: dict = None, **kwargs) -> dict:
+    def check_admin_command_status(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get status of an executed RTR administrator command on a single host.
         """
@@ -78,7 +78,7 @@ class Real_Time_Response_Admin(ServiceClass):
             params=parameters
             )
 
-    def RTR_ExecuteAdminCommand(self: object, body: dict) -> dict:
+    def execute_admin_command(self: object, body: dict) -> dict:
         """
         Execute a RTR administrator command on a single host.
         """
@@ -93,7 +93,7 @@ class Real_Time_Response_Admin(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def RTR_GetPut_Files(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_put_files(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get put-files based on the ID's given. These are used for the RTR `put` command.
         """
@@ -106,12 +106,14 @@ class Real_Time_Response_Admin(ServiceClass):
             params=parameters
             )
 
-    def RTR_CreatePut_Files(self: object, data, files) -> dict:
+    def create_put_files(self: object, data, files) -> dict:
         """
         Upload a new put-file to use for the RTR `put` command.
         """
         # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/real-time-response-admin/RTR_CreatePut_Files
-        header_payload = self.headers
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our content-type header
         header_payload['Content-Type'] = 'multipart/form-data'
         return process_service_request(
             calling_object=self,
@@ -124,7 +126,7 @@ class Real_Time_Response_Admin(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def RTR_DeletePut_Files(self: object, parameters: dict = None, **kwargs) -> dict:
+    def delete_put_files(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Delete a put-file based on the ID given. Can only delete one file at a time.
         """
@@ -139,7 +141,7 @@ class Real_Time_Response_Admin(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def RTR_GetScripts(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_scripts(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get custom-scripts based on the ID's given. These are used for the RTR `runscript` command.
         """
@@ -152,12 +154,14 @@ class Real_Time_Response_Admin(ServiceClass):
             params=parameters
             )
 
-    def RTR_CreateScripts(self: object, data, files) -> dict:
+    def create_scripts(self: object, data, files) -> dict:
         """
         Upload a new custom-script to use for the RTR `runscript` command.
         """
         # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/real-time-response-admin/RTR_CreateScripts
-        header_payload = self.headers
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our content-type header
         header_payload['Content-Type'] = 'multipart/form-data'
         return process_service_request(
             calling_object=self,
@@ -170,7 +174,7 @@ class Real_Time_Response_Admin(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def RTR_DeleteScripts(self: object, parameters: dict = None, **kwargs) -> dict:
+    def delete_scripts(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Delete a custom-script based on the ID given. Can only delete one script at a time.
         """
@@ -184,12 +188,14 @@ class Real_Time_Response_Admin(ServiceClass):
             params=parameters
             )
 
-    def RTR_UpdateScripts(self: object, data, files) -> dict:
+    def update_scripts(self: object, data, files) -> dict:
         """
         Upload a new scripts to replace an existing one.
         """
         # [PATCH] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/real-time-response-admin/RTR_UpdateScripts
-        header_payload = self.headers
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our content-type header
         header_payload['Content-Type'] = 'multipart/form-data'
         return process_service_request(
             calling_object=self,
@@ -202,7 +208,7 @@ class Real_Time_Response_Admin(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def RTR_ListPut_Files(self: object, parameters: dict = None, **kwargs) -> dict:
+    def list_put_files(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get a list of put-file ID's that are available to the user for the `put` command.
         """
@@ -216,7 +222,7 @@ class Real_Time_Response_Admin(ServiceClass):
             )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def RTR_ListScripts(self: object, parameters: dict = None, **kwargs) -> dict:
+    def list_scripts(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get a list of custom-script ID's that are available to the user for the `runscript` command.
         """
@@ -228,3 +234,24 @@ class Real_Time_Response_Admin(ServiceClass):
             keywords=kwargs,
             params=parameters
             )
+
+    # These method names align to the operation IDs in the API but
+    # do not conform to snake_case / PEP8 and are defined here for
+    # backwards compatibility / ease of use purposes
+    BatchAdminCmd = batch_admin_command
+    RTR_CheckAdminCommandStatus = check_admin_command_status
+    RTR_ExecuteAdminCommand = execute_admin_command
+    RTR_GetPut_Files = get_put_files
+    RTR_CreatePut_Files = create_put_files
+    RTR_DeletePut_Files = delete_put_files
+    RTR_GetScripts = get_scripts
+    RTR_CreateScripts = create_scripts
+    RTR_DeleteScripts = delete_scripts
+    RTR_UpdateScripts = update_scripts
+    RTR_ListPut_Files = list_put_files
+    RTR_ListScripts = list_scripts
+
+
+# The legacy name for this class does not conform to PascalCase / PEP8
+# It is defined here for backwards compatibility purposes only.
+Real_Time_Response_Admin = RealTimeResponseAdmin  # pylint: disable=C0103

--- a/src/falconpy/sample_uploads.py
+++ b/src/falconpy/sample_uploads.py
@@ -36,79 +36,79 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
-# pylint: disable=C0103  # Aligning method names to API operation IDs
-from ._util import service_request, force_default, args_to_params
+import json
+from ._util import force_default, process_service_request
 from ._service_class import ServiceClass
 from ._endpoint._sample_uploads import _sample_uploads_endpoints as Endpoints
 
 
-class Sample_Uploads(ServiceClass):
+class SampleUploads(ServiceClass):
     """
     The only requirement to instantiate an instance of this class
-    is a valid token provided by the Falcon API SDK OAuth2 class.
+    is a valid token provided by the Falcon API SDK OAuth2 class, an
+    authorization object (oauth2.py) or a credential dictionary with
+    client_id and client_secret containing valid API credentials.
     """
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def GetSampleV3(self: object, parameters: dict = None, **kwargs) -> object:
+    def get_sample(self: object, parameters: dict = None, **kwargs) -> object:
         """
         Retrieves the file associated with the given ID (SHA256)
         """
-        # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/sample-uploads/GetSampleV3
-        operation_id = "GetSampleV3"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="GetSampleV3",
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters", "body"], default_types=["dict", "dict"])
-    def UploadSampleV3(self: object,
-                       file_data: object,
-                       body: dict = None,
-                       parameters: dict = None,
-                       **kwargs) -> dict:
+    def upload_sample(self: object,
+                      file_data: object,
+                      body: dict = None,
+                      parameters: dict = None,
+                      **kwargs) -> dict:
         """
         Upload a file for further cloud analysis. After uploading, call the specific analysis API endpoint.
         """
-        # [POST] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/sample-uploads/UploadSampleV3
-        operation_id = "UploadSampleV3"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}"
-        header_payload = self.headers
+        # Create a copy of our default header dictionary
+        header_payload = json.loads(json.dumps(self.headers))
+        # Set our content-type header
         header_payload["Content-Type"] = "application/octet-stream"
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        body_payload = body
-        data_payload = file_data
-        returned = service_request(caller=self,
-                                   method="POST",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   body=body_payload,
-                                   data=data_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="POST",
+            operation_id="UploadSampleV3",
+            headers=header_payload,  # Pass our custom headers
+            body=body,
+            data=file_data,
+            keywords=kwargs,
+            params=parameters
+            )
 
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def DeleteSampleV3(self: object, parameters: dict = None, **kwargs) -> dict:
+    def delete_sample(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Removes a sample, including file, meta and submissions from the collection.
         """
-        # [DELETE] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/sample-uploads/DeleteSampleV3
-        operation_id = "DeleteSampleV3"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="DELETE",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            method="DELETE",
+            operation_id="DeleteSampleV3",
+            keywords=kwargs,
+            params=parameters
+            )
+
+    # These method names align to the operation IDs in the API but
+    # do not conform to snake_case / PEP8 and are defined here for
+    # backwards compatibility / ease of use purposes
+    GetSampleV3 = get_sample
+    UploadSampleV3 = upload_sample
+    DeleteSampleV3 = delete_sample
+
+
+# The legacy name for this class does not conform to PascalCase / PEP8
+# It is defined here for backwards compatibility purposes only.
+Sample_Uploads = SampleUploads  # pylint: disable=C0103

--- a/src/falconpy/zero_trust_assessment.py
+++ b/src/falconpy/zero_trust_assessment.py
@@ -36,32 +36,37 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
-# pylint: disable=C0103  # Aligning method names to API operation IDs
-from ._util import service_request, force_default, args_to_params
+from ._util import force_default, process_service_request
 from ._service_class import ServiceClass
 from ._endpoint._zero_trust_assessment import _zero_trust_assessment_endpoints as Endpoints
 
 
-class Zero_Trust_Assessment(ServiceClass):
+class ZeroTrustAssessment(ServiceClass):
     """
     The only requirement to instantiate an instance of this class
-    is a valid token provided by the Falcon API SDK OAuth2 class.
+    is a valid token provided by the Falcon API SDK OAuth2 class, an
+    authorization object (oauth2.py) or a credential dictionary with
+    client_id and client_secret containing valid API credentials.
     """
     @force_default(defaults=["parameters"], default_types=["dict"])
-    def getAssessmentV1(self: object, parameters: dict = None, **kwargs) -> dict:
+    def get_assessment(self: object, parameters: dict = None, **kwargs) -> dict:
         """
         Get Zero Trust Assessment data for one or more hosts by providing agent IDs (AID) and a customer ID (CID).
         """
-        # [GET] https://assets.falcon.crowdstrike.com/support/api/swagger.html#/zero-trust-assessment/getAssessmentV1
-        operation_id = "getAssessmentV1"
-        target_url = f"{self.base_url}{[ep[2] for ep in Endpoints if operation_id in ep[0]][0]}".replace("?ids={}", "")
-        header_payload = self.headers
-        parameter_payload = args_to_params(parameters, kwargs, Endpoints, operation_id)
-        returned = service_request(caller=self,
-                                   method="GET",
-                                   endpoint=target_url,
-                                   params=parameter_payload,
-                                   headers=header_payload,
-                                   verify=self.ssl_verify
-                                   )
-        return returned
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="getAssessmentV1",
+            keywords=kwargs,
+            params=parameters
+            )
+
+    # This method name aligns to the operation ID in the API but
+    # does not conform to snake_case / PEP8 and is defined here for
+    # backwards compatibility / ease of use purposes
+    getAssessmentV1 = get_assessment
+
+
+# The legacy name for this class does not conform to PascalCase / PEP8
+# It is defined here for backwards compatibility purposes only.
+Zero_Trust_Assessment = ZeroTrustAssessment  # pylint: disable=C0103

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -34,6 +34,8 @@ class TestAuthorization():
             self.config = {}
             self.config["falcon_client_id"] = os.getenv("DEBUG_API_ID")
             self.config["falcon_client_secret"] = os.getenv("DEBUG_API_SECRET")
+            if "DEBUG_API_BASE_URL" in os.environ:
+                self.config["falcon_base_url"] = os.getenv("DEBUG_API_BASE_URL")
             return True
         else:
             cur_path = os.path.dirname(os.path.abspath(__file__))
@@ -143,6 +145,12 @@ class TestAuthorization():
             else:
                 return False
         except KeyError:
+            return False
+
+    def credential_logout(self, api: object = None):
+        if api:
+            return bool(api.auth_object.revoke(api.auth_object.token()["body"]["access_token"])["status_code"] in [200, 201])
+        else:
             return False
 
     def test_uberAuth(self):

--- a/tests/test_cloud_connect_aws.py
+++ b/tests/test_cloud_connect_aws.py
@@ -81,25 +81,25 @@ class TestCloudConnectAWS:
 
         return result
 
-    def serviceCCAWS_GetAWSSettings(self):
-        if falcon.GetAWSSettings()["status_code"] in AllowedResponses:
-            return True
-        else:
-            return False
+    # def serviceCCAWS_GetAWSSettings(self):
+    #     if falcon.GetAWSSettings()["status_code"] in AllowedResponses:
+    #         return True
+    #     else:
+    #         return False
 
-    def serviceCCAWS_QueryAWSAccounts(self):
-        if falcon.QueryAWSAccounts(parameters={"limit": 1})["status_code"] in AllowedResponses:
-            return True
-        else:
-            return False
+    # def serviceCCAWS_QueryAWSAccounts(self):
+    #     if falcon.QueryAWSAccounts(parameters={"limit": 1})["status_code"] in AllowedResponses:
+    #         return True
+    #     else:
+    #         return False
 
-    def serviceCCAWS_GetAWSAccounts(self):
-        if falcon.GetAWSAccounts(ids=falcon.QueryAWSAccounts(
-                parameters={"limit": 1}
-                )["body"]["resources"][0]["id"])["status_code"] in AllowedResponses:
-            return True
-        else:
-            return False
+    # def serviceCCAWS_GetAWSAccounts(self):
+    #     if falcon.GetAWSAccounts(ids=falcon.QueryAWSAccounts(
+    #             parameters={"limit": 1}
+    #             )["body"]["resources"][0]["id"])["status_code"] in AllowedResponses:
+    #         return True
+    #     else:
+    #         return False
 
     def serviceCCAWS_GetAWSAccountsUsingList(self):
         liste = []
@@ -125,17 +125,17 @@ class TestCloudConnectAWS:
             accountPayload["resources"][0]["external_id"] = orig_external_id
             return False
 
-    def serviceCCAWS_AccountDelete(self):
-        if falcon.DeleteAWSAccounts(ids=accountPayload["resources"][0]["id"])["status_code"] in AllowedResponses:
-            return True
-        else:
-            return False
+    # def serviceCCAWS_AccountDelete(self):
+    #     if falcon.DeleteAWSAccounts(ids=accountPayload["resources"][0]["id"])["status_code"] in AllowedResponses:
+    #         return True
+    #     else:
+    #         return False
 
-    def serviceCCAWS_AccountRegister(self):
-        if falcon.ProvisionAWSAccounts(body=accountPayload)["status_code"] in AllowedResponses:
-            return True
-        else:
-            return False
+    # def serviceCCAWS_AccountRegister(self):
+    #     if falcon.ProvisionAWSAccounts(body=accountPayload)["status_code"] in AllowedResponses:
+    #         return True
+    #     else:
+    #         return False
 
     def serviceCCAWS_VerifyAWSAccountAccess(self):
         if falcon.VerifyAWSAccountAccess(
@@ -191,16 +191,18 @@ class TestCloudConnectAWS:
         return errorChecks
 
     def test_GetAWSSettings(self):
-        assert self.serviceCCAWS_GetAWSSettings() is True
+        assert bool(falcon.GetAWSSettings()["status_code"] in AllowedResponses) is True
 
     def test_QueryAWSAccounts(self):
-        assert self.serviceCCAWS_QueryAWSAccounts() is True
+        assert bool(falcon.QueryAWSAccounts(parameters={"limit": 1})["status_code"] in AllowedResponses) is True
 
     @pytest.mark.skipif(falcon.QueryAWSAccounts(
         parameters={"limit": 1}
         )["status_code"] == 429, reason="API rate limit reached")
     def test_GetAWSAccounts(self):
-        assert self.serviceCCAWS_GetAWSAccounts() is True
+        assert bool(falcon.GetAWSAccounts(ids=falcon.QueryAWSAccounts(
+                    parameters={"limit": 1}
+                    )["body"]["resources"][0]["id"])["status_code"] in AllowedResponses) is True
 
     @pytest.mark.skipif(falcon.QueryAWSAccounts(
         parameters={"limit": 1}
@@ -225,6 +227,9 @@ class TestCloudConnectAWS:
 
     def test_ForceAttributeError(self):
         assert self.serviceCCAWS_ForceAttributeError() is True
+
+    def test_argument_vs_keyword(self):
+        assert bool(falcon.QueryAWSAccounts(5, limit=1)) is True
 
     def test_Logout(self):
         assert auth.serviceRevoke() is True

--- a/tests/test_custom_ioa.py
+++ b/tests/test_custom_ioa.py
@@ -12,11 +12,12 @@ from tests import test_authorization as Authorization
 # Import our sibling src folder into the path
 sys.path.append(os.path.abspath('src'))
 # Classes to test - manually imported from sibling folder
-from falconpy import custom_ioa as FalconIOA
+from falconpy.custom_ioa import Custom_IOA as FalconIOA
 
 auth = Authorization.TestAuthorization()
-auth.serviceAuth()
-falcon = FalconIOA.Custom_IOA(access_token=auth.token)
+auth.getConfig()
+falcon = FalconIOA(creds={"client_id": auth.config["falcon_client_id"],
+                          "client_secret": auth.config["falcon_client_secret"]})
 AllowedResponses = [200, 201, 207, 429]  # Adding rate-limiting as an allowed response for now
 
 
@@ -70,6 +71,12 @@ class TestCustomIOA:
 
         return errorChecks
 
+    def ioa_logout(self):
+        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] == 200:
+            return True
+        else:
+            return False
+
     def test_QueryPatterns(self):
         assert self.serviceIOA_QueryPatterns() is True
 
@@ -89,7 +96,7 @@ class TestCustomIOA:
         assert self.serviceIOA_QueryRulesMixin0() is True
 
     def test_Logout(self):
-        assert auth.serviceRevoke() is True
+        assert self.ioa_logout() is True
 
     def test_Errors(self):
         assert self.serviceIOA_GenerateErrors() is True

--- a/tests/test_custom_ioa.py
+++ b/tests/test_custom_ioa.py
@@ -1,14 +1,10 @@
-# test_custom_ioa.py
-# This class tests the custom_ioa service class
-
-# import json
+"""
+test_custom_ioa.py - This class tests the custom_ioa service class
+"""
 import os
 import sys
-# import datetime
-# import pytest
 # Authentication via the test_authorization.py
 from tests import test_authorization as Authorization
-
 # Import our sibling src folder into the path
 sys.path.append(os.path.abspath('src'))
 # Classes to test - manually imported from sibling folder
@@ -22,81 +18,73 @@ AllowedResponses = [200, 201, 207, 429]  # Adding rate-limiting as an allowed re
 
 
 class TestCustomIOA:
-
-    def serviceIOA_QueryPatterns(self):
-        return falcon.query_patterns()["status_code"] in AllowedResponses
-
-    def serviceIOA_QueryPlatformsMixin0(self):
-        return falcon.query_platformsMixin0()["status_code"] in AllowedResponses
-
-    def serviceIOA_QueryRuleGroupsFull(self):
-        return falcon.query_rule_groups_full()["status_code"] in AllowedResponses
-
-    def serviceIOA_QueryRuleGroupsMixin0(self):
-        return falcon.query_rule_groupsMixin0()["status_code"] in AllowedResponses
-
-    def serviceIOA_QueryRuleTypes(self):
-        return falcon.query_rule_types()["status_code"] in AllowedResponses
-
-    def serviceIOA_QueryRulesMixin0(self):
-        return falcon.query_rulesMixin0()["status_code"] in AllowedResponses
-
-    def serviceIOA_GenerateErrors(self):
+    """Custom IOA Service Class test harness"""
+    @staticmethod
+    def ioa_generate_errors():
+        """Generates errors for every operation and tests every code path"""
         falcon.base_url = "nowhere"
-        errorChecks = True
-        commandList = [
-            ["get_patterns", "ids='12345678'"],
-            ["get_platformsMixin0", "ids='12345678'"],
-            ["get_rule_groupsMixin0", "ids='12345678'"],
-            ["create_rule_groupMixin0", "body={}, cs_username='falconpy_unit_testing'"],
-            ["delete_rule_groupMixin0", "ids='12345678', cs_username='falconpy_unit_testing'"],
-            ["update_rule_groupMixin0", "body={}, cs_username='falconpy_unit_testing'"],
-            ["get_rule_types", "ids='12345678'"],
-            ["get_rules_get", "ids=['12345678','23456789','09876544']"],
-            ["get_rulesMixin0", "ids='12345678'"],
-            ["create_rule", "body={}, cs_username='falconpy_unit_testing'"],
-            ["delete_rules", "ids='12345678', cs_username='falconpy_unit_testing'"],
-            ["update_rules", "body={}, cs_username='falconpy_unit_testing'"],
-            ["validate", "body={}"],
-            ["query_patterns", ""],
-            ["query_platformsMixin0", ""],
-            ["query_rule_groups_full", ""],
-            ["query_rule_groupsMixin0", ""],
-            ["query_rule_types", ""],
-            ["query_rulesMixin0", ""]
-        ]
-        for cmd in commandList:
-            if eval("falcon.{}({})['status_code']".format(cmd[0], cmd[1])) != 500:
-                errorChecks = False
+        error_checks = True
+        # Intentionally crossing both code patterns for a while with this - jshcodes @ 08.10.21
+        tests = {
+            "get_patterns": falcon.get_patterns(ids='12345678')["status_code"],
+            "get_platforms": falcon.get_platformsMixin0(ids='12345678')["status_code"],
+            "get_rule_groups": falcon.get_rule_groupsMixin0(ids='12345678')["status_code"],
+            "create_rule_group": falcon.create_rule_groupMixin0(body={}, cs_username='falconpy_unit_testing')["status_code"],
+            "delete_rule_group": falcon.delete_rule_groupMixin0(
+                ids='12345678', cs_username='falconpy_unit_testing'
+                )["status_code"],
+            "update_rule_group": falcon.update_rule_groupMixin0(body={}, cs_username='falconpy_unit_testing')["status_code"],
+            "get_rule_types": falcon.get_rule_types(ids='12345678')["status_code"],
+            "get_rules_get": falcon.get_rules_get(ids=['12345678', '23456789', '09876544'])["status_code"],
+            "get_rules": falcon.get_rulesMixin0(ids='12345678')["status_code"],
+            "create_rule": falcon.create_rule(body={}, cs_username='falconpy_unit_testing')["status_code"],
+            "delete_rules": falcon.delete_rules(ids='12345678', cs_username='falconpy_unit_testing')["status_code"],
+            "update_rules": falcon.update_rules(body={}, cs_username='falconpy_unit_testing')["status_code"],
+            "validate": falcon.validate(body={})["status_code"],
+            "query_patterns": falcon.query_patterns()["status_code"],
+            "query_platforms": falcon.query_platformsMixin0()["status_code"],
+            "query_rule_groups_full": falcon.query_rule_groups_full()["status_code"],
+            "query_rule_groups": falcon.query_rule_groupsMixin0()["status_code"],
+            "query_rule_types": falcon.query_rule_types()["status_code"],
+            "query_rules": falcon.query_rulesMixin0()["status_code"]
+        }
+        for key in tests:
+            if tests[key] != 500:
+                error_checks = False
 
-        return errorChecks
+        return error_checks
 
-    def ioa_logout(self):
-        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] == 200:
-            return True
-        else:
-            return False
+    def test_query_patterns(self):
+        """Pytest harness hook"""
+        assert bool(falcon.query_patterns()["status_code"] in AllowedResponses) is True
 
-    def test_QueryPatterns(self):
-        assert self.serviceIOA_QueryPatterns() is True
+    def test_query_platforms(self):
+        """Pytest harness hook"""
+        assert bool(falcon.query_platformsMixin0()["status_code"] in AllowedResponses) is True
 
-    def test_QueryPlatformsMixin0(self):
-        assert self.serviceIOA_QueryPlatformsMixin0() is True
+    def test_query_rule_groups_full(self):
+        """Pytest harness hook"""
+        assert bool(falcon.query_rule_groups_full()["status_code"] in AllowedResponses) is True
 
-    def test_QueryRuleGroupsFull(self):
-        assert self.serviceIOA_QueryRuleGroupsFull() is True
+    def test_query_rule_groups(self):
+        """Pytest harness hook"""
+        assert bool(falcon.query_rule_groupsMixin0()["status_code"] in AllowedResponses) is True
 
-    def test_QueryRuleGroupsMixin0(self):
-        assert self.serviceIOA_QueryRuleGroupsMixin0() is True
+    def test_query_rule_types(self):
+        """Pytest harness hook"""
+        assert bool(falcon.query_rule_types()["status_code"] in AllowedResponses) is True
 
-    def test_QueryRuleTypes(self):
-        assert self.serviceIOA_QueryRuleTypes() is True
+    def test_query_rules(self):
+        """Pytest harness hook"""
+        assert bool(falcon.query_rulesMixin0()["status_code"] in AllowedResponses) is True
 
-    def test_QueryRulesMixin0(self):
-        assert self.serviceIOA_QueryRulesMixin0() is True
+    def test_errors(self):
+        """Pytest harness hook"""
+        assert self.ioa_generate_errors() is True
 
-    def test_Logout(self):
-        assert self.ioa_logout() is True
-
-    def test_Errors(self):
-        assert self.serviceIOA_GenerateErrors() is True
+    @staticmethod
+    def test_logout():
+        """Pytest harness hook"""
+        assert bool(falcon.auth_object.revoke(
+            falcon.auth_object.token()["body"]["access_token"]
+            )["status_code"] in [200, 201]) is True

--- a/tests/test_event_streams.py
+++ b/tests/test_event_streams.py
@@ -1,7 +1,5 @@
 # test_event_streams.py
 # This class tests the event_streams service class
-
-import json
 import os
 import sys
 import datetime
@@ -10,35 +8,50 @@ import pytest
 # Authentication via the test_authorization.py
 from tests import test_authorization as Authorization
 
-#Import our sibling src folder into the path
+# Import our sibling src folder into the path
 sys.path.append(os.path.abspath('src'))
 # Classes to test - manually imported from sibling folder
-from falconpy import event_streams as FalconStream
+from falconpy.event_streams import Event_Streams
 
 auth = Authorization.TestAuthorization()
-auth.serviceAuth()
-falcon = FalconStream.Event_Streams(access_token=auth.token)
-AllowedResponses = [200, 429] #Adding rate-limiting as an allowed response for now
+# Moving to credential authentication
+auth.getConfig()
+falcon = Event_Streams(creds={"client_id": auth.config["falcon_client_id"],
+                              "client_secret": auth.config["falcon_client_secret"]})
+
+AllowedResponses = [200, 429]  # Adding rate-limiting as an allowed response for now
 appId = "pytest-event_streams-unit-test"
+
+
 class TestEventStreams:
 
     def serviceStream_listAvailableStreamsOAuth2(self):
-        if falcon.listAvailableStreamsOAuth2(parameters={"appId":"pytest-event_streams-unit-test"})["status_code"] in AllowedResponses:
+        if falcon.listAvailableStreamsOAuth2(
+                parameters={"appId": f"{appId}"}
+                )["status_code"] in AllowedResponses:
             return True
         else:
             return False
-          
+
     def serviceStream_refreshActiveStreamSession(self):
-        avail = falcon.listAvailableStreamsOAuth2(parameters={"appId":"pytest-event_streams-unit-test"})
+        avail = falcon.listAvailableStreamsOAuth2(parameters={"appId": f"{appId}"})
         t1 = datetime.datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S +0000')
-        headers = {'Authorization': 'Token %s' % (avail["body"]["resources"][0]["sessionToken"]["token"]), 'Date': t1, 'Connection': 'Keep-Alive'}
+        headers = {
+            'Authorization': 'Token %s' % (
+                avail["body"]["resources"][0]["sessionToken"]["token"]
+                ), 'Date': t1, 'Connection': 'Keep-Alive'
+            }
         stream = requests.get(avail["body"]["resources"][0]["dataFeedURL"], headers=headers, stream=True)
         with stream:
-            if falcon.refreshActiveStreamSession(parameters={"appId": "pytest-event_streams-unit-test", "action_name":"refresh_active_stream_session"}, partition=0)["status_code"] in AllowedResponses:
+            result = falcon.refreshActiveStreamSession(appId=f"{appId}",
+                                                       action_name="refresh_active_stream_session",
+                                                       partition="0"
+                                                       )
+            if result["status_code"] in AllowedResponses:
                 return True
             else:
                 return False
-    
+
     def serviceStream_GenerateErrors(self):
         falcon.base_url = "nowhere"
         errorChecks = True
@@ -49,15 +62,25 @@ class TestEventStreams:
 
         return errorChecks
 
-    def test_listAvailableStreamsOAuth2(self):
-        assert self.serviceStream_listAvailableStreamsOAuth2() == True
+    def serviceStream_Logout(self):
+        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] == 200:
+            return True
+        else:
+            return False
 
-    #@pytest.mark.skipif(falcon.listAvailableStreamsOAuth2(parameters={"appId":"pytest-event_streams-unit-test"})["status_code"] == 429, reason="API rate limit reached")
-    # def test_refreshActiveStreamSession(self):
-    #     assert self.serviceStream_refreshActiveStreamSession() == True
+    def test_list(self):
+        assert self.serviceStream_listAvailableStreamsOAuth2() is True
 
-    def test_Logout(self):
-        assert auth.serviceRevoke() == True
+    @pytest.mark.skipif(
+      falcon.listAvailableStreamsOAuth2(
+          parameters={"appId": "pytest-event_streams-unit-test"}
+          )["status_code"] == 429, reason="API rate limit reached"
+      )
+    def test_refresh(self):
+        assert self.serviceStream_refreshActiveStreamSession() is True
 
-    def test_Errors(self):
-        assert self.serviceStream_GenerateErrors() == True
+    def test_logout(self):
+        assert self.serviceStream_Logout() is True
+
+    def test_errors(self):
+        assert self.serviceStream_GenerateErrors() is True

--- a/tests/test_event_streams.py
+++ b/tests/test_event_streams.py
@@ -66,11 +66,6 @@ class TestEventStreams:
 
         return error_checks
 
-    @staticmethod
-    def stream_logout():
-        """Tests logout and discards the token"""
-        return bool(falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] == 200)
-
     def test_list(self):
         """Pylint test harness hook"""
         assert self.stream_list() is True
@@ -78,13 +73,17 @@ class TestEventStreams:
     @pytest.mark.skipif(sys.version_info.minor < 9, reason="Frequency reduced due to test flakiness")
     @pytest.mark.skipif(platform.system() != "Darwin", reason="Frequency reduced due to test flakiness")
     def test_refresh(self):
-        """Pylint test harness hook"""
+        """Pytest harness hook"""
         assert self.stream_refresh() is True
 
-    def test_logout(self):
-        """Pylint test harness hook"""
-        assert self.stream_logout() is True
 
     def test_errors(self):
-        """Pylint test harness hook"""
+        """Pytest harness hook"""
         assert self.stream_errors() is True
+
+    @staticmethod
+    def test_logout():
+        """Pytest harness hook"""
+        assert bool(falcon.auth_object.revoke(
+            falcon.auth_object.token()["body"]["access_token"]
+            )["status_code"] in [200, 201]) is True

--- a/tests/test_event_streams.py
+++ b/tests/test_event_streams.py
@@ -5,6 +5,7 @@ import sys
 import datetime
 import requests
 import pytest
+import platform
 # Authentication via the test_authorization.py
 from tests import test_authorization as Authorization
 
@@ -72,6 +73,7 @@ class TestEventStreams:
         assert self.serviceStream_listAvailableStreamsOAuth2() is True
 
     @pytest.mark.skipif(sys.version_info.minor < 9, reason="Frequency reduced due to test flakiness")
+    @pytest.mark.skipif(platform.system() != "Darwin", reason="Frequency reduced due to test flakiness")
     def test_refresh(self):
         assert self.serviceStream_refreshActiveStreamSession() is True
 

--- a/tests/test_event_streams.py
+++ b/tests/test_event_streams.py
@@ -71,11 +71,7 @@ class TestEventStreams:
     def test_list(self):
         assert self.serviceStream_listAvailableStreamsOAuth2() is True
 
-    @pytest.mark.skipif(
-      falcon.listAvailableStreamsOAuth2(
-          parameters={"appId": "pytest-event_streams-unit-test"}
-          )["status_code"] == 429, reason="API rate limit reached"
-      )
+    @pytest.mark.skipif(sys.version_info.minor < 9, reason="Frequency reduced due to test flakiness")
     def test_refresh(self):
         assert self.serviceStream_refreshActiveStreamSession() is True
 

--- a/tests/test_event_streams.py
+++ b/tests/test_event_streams.py
@@ -1,17 +1,20 @@
-# test_event_streams.py
-# This class tests the event_streams service class
+"""
+test_event_streams.py - This class tests the event_streams service class
+"""
+# pylint: disable=E0401,C0413
 import os
 import sys
 import datetime
+import platform
 import requests
 import pytest
-import platform
 # Authentication via the test_authorization.py
 from tests import test_authorization as Authorization
 
 # Import our sibling src folder into the path
 sys.path.append(os.path.abspath('src'))
 # Classes to test - manually imported from sibling folder
+# flake8: noqa=E402
 from falconpy.event_streams import Event_Streams
 
 auth = Authorization.TestAuthorization()
@@ -21,64 +24,67 @@ falcon = Event_Streams(creds={"client_id": auth.config["falcon_client_id"],
                               "client_secret": auth.config["falcon_client_secret"]})
 
 AllowedResponses = [200, 429]  # Adding rate-limiting as an allowed response for now
-appId = "pytest-event_streams-unit-test"
+APP_ID = "pytest-event_streams-unit-test"
 
 
 class TestEventStreams:
+    """Test harness for the Event Streams service class"""
+    @staticmethod
+    def stream_list():
+        """list_available_streams"""
+        return bool(falcon.listAvailableStreamsOAuth2(
+                parameters={"appId": f"{APP_ID}"}
+                )["status_code"] in AllowedResponses)
 
-    def serviceStream_listAvailableStreamsOAuth2(self):
-        if falcon.listAvailableStreamsOAuth2(
-                parameters={"appId": f"{appId}"}
-                )["status_code"] in AllowedResponses:
-            return True
-        else:
-            return False
-
-    def serviceStream_refreshActiveStreamSession(self):
-        avail = falcon.listAvailableStreamsOAuth2(parameters={"appId": f"{appId}"})
-        t1 = datetime.datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S +0000')
+    @staticmethod
+    def stream_refresh():
+        """refresh_active_stream"""
+        avail = falcon.listAvailableStreamsOAuth2(parameters={"appId": f"{APP_ID}"})
+        current_time = datetime.datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S +0000')
         headers = {
             'Authorization': 'Token %s' % (
                 avail["body"]["resources"][0]["sessionToken"]["token"]
-                ), 'Date': t1, 'Connection': 'Keep-Alive'
+                ), 'Date': current_time, 'Connection': 'Keep-Alive'
             }
         stream = requests.get(avail["body"]["resources"][0]["dataFeedURL"], headers=headers, stream=True)
         with stream:
-            result = falcon.refreshActiveStreamSession(appId=f"{appId}",
+            result = falcon.refreshActiveStreamSession(appId=f"{APP_ID}",
                                                        action_name="refresh_active_stream_session",
                                                        partition="0"
                                                        )
-            if result["status_code"] in AllowedResponses:
-                return True
-            else:
-                return False
+            return bool(result["status_code"] in AllowedResponses)
 
-    def serviceStream_GenerateErrors(self):
+    @staticmethod
+    def stream_errors():
+        """Generates errors to test remaining code paths"""
         falcon.base_url = "nowhere"
-        errorChecks = True
+        error_checks = True
         if falcon.listAvailableStreamsOAuth2(parameters={})["status_code"] != 500:
-            errorChecks = False
+            error_checks = False
         if falcon.refreshActiveStreamSession(parameters={}, partition=0)["status_code"] != 500:
-            errorChecks = False
+            error_checks = False
 
-        return errorChecks
+        return error_checks
 
-    def serviceStream_Logout(self):
-        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] == 200:
-            return True
-        else:
-            return False
+    @staticmethod
+    def stream_logout():
+        """Tests logout and discards the token"""
+        return bool(falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] == 200)
 
     def test_list(self):
-        assert self.serviceStream_listAvailableStreamsOAuth2() is True
+        """Pylint test harness hook"""
+        assert self.stream_list() is True
 
     @pytest.mark.skipif(sys.version_info.minor < 9, reason="Frequency reduced due to test flakiness")
     @pytest.mark.skipif(platform.system() != "Darwin", reason="Frequency reduced due to test flakiness")
     def test_refresh(self):
-        assert self.serviceStream_refreshActiveStreamSession() is True
+        """Pylint test harness hook"""
+        assert self.stream_refresh() is True
 
     def test_logout(self):
-        assert self.serviceStream_Logout() is True
+        """Pylint test harness hook"""
+        assert self.stream_logout() is True
 
     def test_errors(self):
-        assert self.serviceStream_GenerateErrors() is True
+        """Pylint test harness hook"""
+        assert self.stream_errors() is True

--- a/tests/test_firewall_management.py
+++ b/tests/test_firewall_management.py
@@ -1,5 +1,4 @@
-# test_firewall_management.py
-# This class tests the firewall_management service class
+""" test_firewall_management.py - This class tests the firewall_management service class"""
 import os
 import sys
 # Authentication via the test_authorization.py
@@ -12,97 +11,59 @@ from falconpy.firewall_management import Firewall_Management as FalconFirewall
 auth = Authorization.TestAuthorization()
 auth.getConfig()
 falcon = FalconFirewall(creds={"client_id": auth.config["falcon_client_id"],
-                               "client_secret": auth.config["falcon_client_secret"]})
-AllowedResponses = [200, 429]  # Adding rate-limiting as an allowed response for now
+                               "client_secret": auth.config["falcon_client_secret"]
+                               })
+AllowedResponses = [200, 201, 400, 404, 429]
 
 
 class TestFirewallManagement:
+    """Test harness for the Firewall Management Service Class"""
+    @staticmethod
+    def firewall_test_all_code_paths():
+        """Test every code path, accepts all errors except 500"""
+        error_checks = True
+        tests = {
+            "aggregate_events": falcon.aggregate_events(body={})["status_code"],
+            "aggregate_policy_rules": falcon.aggregate_policy_rules(body={})["status_code"],
+            "aggregate_rule_groups": falcon.aggregate_rule_groups(body={})["status_code"],
+            "aggregate_rules": falcon.aggregate_rules(body={})["status_code"],
+            "get_events": falcon.get_events(ids="12345678")["status_code"],
+            "get_firewall_fields": falcon.get_firewall_fields(ids="12345678")["status_code"],
+            "get_platforms": falcon.get_platforms(ids="12345678")["status_code"],
+            "get_policy_containers": falcon.get_policy_containers(ids="12345678")["status_code"],
+            "update_policy_container": falcon.update_policy_container(body={}, cs_username="BillTheCat")["status_code"],
+            "get_rule_groups": falcon.get_rule_groups(ids="12345678")["status_code"],
+            "create_rule_group": falcon.create_rule_group(body={}, cs_username="HarryHenderson")["status_code"],
+            "delete_rule_groups": falcon.delete_rule_groups(ids="12345678", cs_username="KyloRen")["status_code"],
+            "update_rule_group": falcon.update_rule_group(body={}, cs_username="Calcifer")["status_code"],
+            "get_rules": falcon.get_rules(ids="12345678")["status_code"],
+            "query_events": falcon.query_events()["status_code"],
+            "query_firewall_fields": falcon.query_firewall_fields()["status_code"],
+            "query_platforms": falcon.query_platforms()["status_code"],
+            "query_policy_rules": falcon.query_policy_rules()["status_code"],
+            "query_rule_groups": falcon.query_rule_groups()["status_code"],
+            "query_rules": falcon.query_rules()["status_code"]
 
-    def serviceFirewall_query_rules(self):
-        if falcon.query_rules(parameters={"limit":1})["status_code"] in AllowedResponses:
-            return True
-        else:
-            return False
+        }
+        for key in tests:
+            if tests[key] not in AllowedResponses:
+                error_checks = False
+                # print(f"Failed on {key} with {tests[key]}")
 
-    def serviceFirewall_GenerateErrors(self):
-        falcon.base_url = "nowhere"
-        errorChecks = True
-        if falcon.aggregate_events(body={})["status_code"] != 500:
-            errorChecks = False
-            print("1")
-        if falcon.aggregate_policy_rules(body={})["status_code"] != 500:
-            errorChecks = False
-            print("2")
-        if falcon.aggregate_rule_groups(body={})["status_code"] != 500:
-            errorChecks = False
-            print("3")
-        if falcon.aggregate_rules(body={})["status_code"] != 500:
-            errorChecks = False
-            print("4")
-        if falcon.get_events(ids="12345678")["status_code"] != 500:
-            errorChecks = False
-            print("5")
-        if falcon.get_firewall_fields(ids="12345678")["status_code"] != 500:
-            errorChecks = False
-            print("6")
-        if falcon.get_platforms(ids="12345678")["status_code"] != 500:
-            errorChecks = False
-            print("7")
-        if falcon.get_policy_containers(ids="12345678")["status_code"] != 500:
-            errorChecks = False
-            print("8")
-        if falcon.update_policy_container(body={}, cs_username="BillTheCat")["status_code"] != 500:
-            errorChecks = False
-            print("9")
-        if falcon.get_rule_groups(ids="12345678")["status_code"] != 500:
-            errorChecks = False
-            print("10")
-        if falcon.create_rule_group(body={}, cs_username="HarryHenderson")["status_code"] != 500:
-            errorChecks = False
-            print("11")
-        if falcon.delete_rule_groups(ids="12345678", cs_username="KyloRen")["status_code"] != 500:
-            errorChecks = False
-            print("12")
-        if falcon.update_rule_group(body={}, cs_username="Calcifer")["status_code"] != 500:
-            errorChecks = False
-            print("13")
-        if falcon.get_rules(ids="12345678")["status_code"] != 500:
-            errorChecks = False
-            print("14")
-        if falcon.query_events()["status_code"] != 500:
-            errorChecks = False
-            print("15")
-        if falcon.query_firewall_fields()["status_code"] != 500:
-            errorChecks = False
-            print("16")
-        if falcon.query_platforms()["status_code"] != 500:
-            errorChecks = False
-            print("17")
-        if falcon.query_policy_rules()["status_code"] != 500:
-            errorChecks = False
-            print("18")
-        if falcon.query_rule_groups()["status_code"] != 500:
-            errorChecks = False
-            print("19")
-        if falcon.query_rules()["status_code"] != 500:
-            errorChecks = False
-            print("20")
+        return error_checks
 
-        return errorChecks
+    @staticmethod
+    def test_query_rules():
+        """Pytest harness hook"""
+        assert bool(falcon.query_rules(parameters={"limit": 1})["status_code"] in AllowedResponses) is True
 
-    def firewall_logout(self):
-        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] == 200:
-            return True
-        else:
-            return False
+    def test_all_paths(self):
+        """Pytest harness hook"""
+        assert self.firewall_test_all_code_paths() is True
 
-    # def test_query_rules(self):
-    #     assert self.serviceFirewall_query_rules() == True
-
-    def test_Logout(self):
-        assert self.firewall_logout() is True
-
-    def test_Errors(self):
-        assert self.serviceFirewall_GenerateErrors() is True
-
-#TODO: My current API key can't hit this API. Pending additional unit testing for now.
+    @staticmethod
+    def test_logout():
+        """Pytest harness hook"""
+        assert bool(falcon.auth_object.revoke(
+            falcon.auth_object.token()["body"]["access_token"]
+            )["status_code"] in [200, 201]) is True

--- a/tests/test_firewall_management.py
+++ b/tests/test_firewall_management.py
@@ -1,20 +1,20 @@
 # test_firewall_management.py
 # This class tests the firewall_management service class
-
-import json
 import os
 import sys
 # Authentication via the test_authorization.py
 from tests import test_authorization as Authorization
-#Import our sibling src folder into the path
+# Import our sibling src folder into the path
 sys.path.append(os.path.abspath('src'))
 # Classes to test - manually imported from sibling folder
-from falconpy import firewall_management as FalconFirewall
+from falconpy.firewall_management import Firewall_Management as FalconFirewall
 
 auth = Authorization.TestAuthorization()
-auth.serviceAuth()
-falcon = FalconFirewall.Firewall_Management(access_token=auth.token)
-AllowedResponses = [200, 429] #Adding rate-limiting as an allowed response for now
+auth.getConfig()
+falcon = FalconFirewall(creds={"client_id": auth.config["falcon_client_id"],
+                               "client_secret": auth.config["falcon_client_secret"]})
+AllowedResponses = [200, 429]  # Adding rate-limiting as an allowed response for now
+
 
 class TestFirewallManagement:
 
@@ -23,7 +23,6 @@ class TestFirewallManagement:
             return True
         else:
             return False
-
 
     def serviceFirewall_GenerateErrors(self):
         falcon.base_url = "nowhere"
@@ -88,16 +87,22 @@ class TestFirewallManagement:
         if falcon.query_rules()["status_code"] != 500:
             errorChecks = False
             print("20")
-            
+
         return errorChecks
+
+    def firewall_logout(self):
+        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] == 200:
+            return True
+        else:
+            return False
 
     # def test_query_rules(self):
     #     assert self.serviceFirewall_query_rules() == True
 
     def test_Logout(self):
-        assert auth.serviceRevoke() == True
+        assert self.firewall_logout() is True
 
     def test_Errors(self):
-        assert self.serviceFirewall_GenerateErrors() == True
+        assert self.serviceFirewall_GenerateErrors() is True
 
 #TODO: My current API key can't hit this API. Pending additional unit testing for now.

--- a/tests/test_real_time_response_admin.py
+++ b/tests/test_real_time_response_admin.py
@@ -1,32 +1,32 @@
 # test_real_time_response_admin.py
 # This class tests the real_time_response_admin service class
 
-import json
 import os
 import sys
-import pytest
 # Authentication via the test_authorization.py
 from tests import test_authorization as Authorization
-#Import our sibling src folder into the path
+# Import our sibling src folder into the path
 sys.path.append(os.path.abspath('src'))
 # Classes to test - manually imported from sibling folder
-from falconpy import real_time_response_admin as FalconRTR
+from falconpy.real_time_response_admin import Real_Time_Response_Admin as FalconRTR
 
 auth = Authorization.TestAuthorization()
-auth.serviceAuth()
-falcon = FalconRTR.Real_Time_Response_Admin(access_token=auth.token)
-AllowedResponses = [200, 429] #Adding rate-limiting as an allowed response for now
+auth.getConfig()
+falcon = FalconRTR(creds={"client_id": auth.config["falcon_client_id"],
+                          "client_secret": auth.config["falcon_client_secret"]})
+AllowedResponses = [200, 429]  # Adding rate-limiting as an allowed response for now
+
 
 class TestRTR:
 
     def serviceRTR_ListPut_Files(self):
-        if falcon.RTR_ListPut_Files(parameters={"limit":1})["status_code"] in AllowedResponses:
+        if falcon.RTR_ListPut_Files(parameters={"limit": 1})["status_code"] in AllowedResponses:
             return True
         else:
             return False
 
     def serviceRTR_ListScripts(self):
-        if falcon.RTR_ListScripts(parameters={"limit":1})["status_code"] in AllowedResponses:
+        if falcon.RTR_ListScripts(parameters={"limit": 1})["status_code"] in AllowedResponses:
             return True
         else:
             return False
@@ -35,33 +35,39 @@ class TestRTR:
         falcon.base_url = "nowhere"
         errorChecks = True
         commandList = [
-            ["BatchAdminCmd","body={}"],
-            ["RTR_CheckAdminCommandStatus","parameters={}"],
-            ["RTR_ExecuteAdminCommand","body={}"],
-            ["RTR_GetPut_Files","ids='12345678'"],
-            ["RTR_CreatePut_Files","data={}, files=[]"],
-            ["RTR_DeletePut_Files","ids='12345678'"],
-            ["RTR_GetScripts","ids='12345678'"],
-            ["RTR_CreateScripts","data={}, files=[]"],
-            ["RTR_DeleteScripts","ids='12345678'"],
-            ["RTR_UpdateScripts","data={}, files=[]"],
-            ["RTR_ListPut_Files",""],
-            ["RTR_ListScripts",""]
+            ["BatchAdminCmd", "body={}"],
+            ["RTR_CheckAdminCommandStatus", "parameters={}"],
+            ["RTR_ExecuteAdminCommand", "body={}"],
+            ["RTR_GetPut_Files", "ids='12345678'"],
+            ["RTR_CreatePut_Files", "data={}, files=[]"],
+            ["RTR_DeletePut_Files", "ids='12345678'"],
+            ["RTR_GetScripts", "ids='12345678'"],
+            ["RTR_CreateScripts", "data={}, files=[]"],
+            ["RTR_DeleteScripts", "ids='12345678'"],
+            ["RTR_UpdateScripts", "data={}, files=[]"],
+            ["RTR_ListPut_Files", ""],
+            ["RTR_ListScripts", ""]
         ]
         for cmd in commandList:
-            if eval("falcon.{}({})['status_code']".format(cmd[0],cmd[1])) != 500:
+            if eval("falcon.{}({})['status_code']".format(cmd[0], cmd[1])) != 500:
                 errorChecks = False
-        
+
         return errorChecks
 
+    def rtr_logout(self):
+        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] == 200:
+            return True
+        else:
+            return False
+
     def test_RTR_ListScripts(self):
-        assert self.serviceRTR_ListScripts() == True
+        assert self.serviceRTR_ListScripts() is True
 
     def test_RTR_ListPut_Files(self):
-        assert self.serviceRTR_ListPut_Files() == True
+        assert self.serviceRTR_ListPut_Files() is True
 
     def test_Logout(self):
-        assert auth.serviceRevoke() == True
-    
+        assert self.rtr_logout() is True
+
     def test_Errors(self):
-        assert self.serviceRTR_GenerateErrors() == True
+        assert self.serviceRTR_GenerateErrors() is True

--- a/tests/test_real_time_response_admin.py
+++ b/tests/test_real_time_response_admin.py
@@ -1,6 +1,7 @@
 # test_real_time_response_admin.py
 # This class tests the real_time_response_admin service class
-
+import datetime
+import requests
 import os
 import sys
 # Authentication via the test_authorization.py
@@ -13,61 +14,71 @@ from falconpy.real_time_response_admin import Real_Time_Response_Admin as Falcon
 auth = Authorization.TestAuthorization()
 auth.getConfig()
 falcon = FalconRTR(creds={"client_id": auth.config["falcon_client_id"],
-                          "client_secret": auth.config["falcon_client_secret"]})
-AllowedResponses = [200, 201, 429]  # Adding rate-limiting as an allowed response for now
+                          "client_secret": auth.config["falcon_client_secret"]
+                          })
+AllowedResponses = [200, 201, 400, 404, 429]
 
 
 class TestRTR:
 
-    def serviceRTR_ListPut_Files(self):
+    def rtra_list_put_files(self):
         if falcon.RTR_ListPut_Files(parameters={"limit": 1})["status_code"] in AllowedResponses:
             return True
         else:
             return False
 
-    def serviceRTR_ListScripts(self):
+    def rtra_list_scripts(self):
         if falcon.RTR_ListScripts(parameters={"limit": 1})["status_code"] in AllowedResponses:
             return True
         else:
             return False
 
-    def serviceRTR_GenerateErrors(self):
-        falcon.base_url = "nowhere"
-        errorChecks = True
-        commandList = [
-            ["BatchAdminCmd", "body={}"],
-            ["RTR_CheckAdminCommandStatus", "parameters={}"],
-            ["RTR_ExecuteAdminCommand", "body={}"],
-            ["RTR_GetPut_Files", "ids='12345678'"],
-            ["RTR_CreatePut_Files", "data={}, files=[]"],
-            ["RTR_DeletePut_Files", "ids='12345678'"],
-            ["RTR_GetScripts", "ids='12345678'"],
-            ["RTR_CreateScripts", "data={}, files=[]"],
-            ["RTR_DeleteScripts", "ids='12345678'"],
-            ["RTR_UpdateScripts", "data={}, files=[]"],
-            ["RTR_ListPut_Files", ""],
-            ["RTR_ListScripts", ""]
+    def rtra_test_all_code_paths(self):
+        upload_file = "tests/testfile.png"
+        fmt = '%Y-%m-%d %H:%M:%S'
+        stddate = datetime.datetime.now().strftime(fmt)
+        sdtdate = datetime.datetime.strptime(stddate, fmt)
+        sdtdate = sdtdate.timetuple()
+        jdate = sdtdate.tm_yday
+        jdate = "{}{}".format(stddate.replace("-", "").replace(":", "").replace(" ", ""), jdate)
+        upload_filename = "%s_testfile.png" % jdate
+
+        file_payload = {'name': upload_filename, 'description': 'FalconPy Unit Testing'}
+        files_detail = [
+            ('file', ('testfile.png', open(upload_file, 'rb'), 'image/png'))
         ]
-        for cmd in commandList:
-            if eval("falcon.{}({})['status_code']".format(cmd[0], cmd[1])) != 500:
-                errorChecks = False
 
-        return errorChecks
+        error_checks = True
+        tests = {
+            "batch_admin_cmd": falcon.BatchAdminCmd(body={})["status_code"],
+            "check_admin_command_status": falcon.RTR_CheckAdminCommandStatus(parameters={})["status_code"],
+            "execute_admin_command": falcon.RTR_ExecuteAdminCommand(body={})["status_code"],
+            "get_put_files": falcon.RTR_GetPut_Files(ids='12345678')["status_code"],
+            "create_put_files": falcon.RTR_CreatePut_Files(data=file_payload, files=files_detail)["status_code"],
+            "delete_put_files": falcon.RTR_DeletePut_Files(ids='12345678')["status_code"],
+            "get_scripts": falcon.RTR_GetScripts(ids='12345678')["status_code"],
+            "create_scripts": falcon.RTR_CreateScripts(data={}, files=[])["status_code"],
+            "delete_scripts": falcon.RTR_DeleteScripts(ids='12345678')["status_code"],
+            "update_scripts": falcon.RTR_UpdateScripts(data={}, files=[])["status_code"],
+            "list_put_files": falcon.RTR_ListPut_Files()["status_code"],
+            "list_scripts": falcon.RTR_ListScripts()["status_code"]
+        }
+        for key in tests:
+            if tests[key] not in AllowedResponses:
+                error_checks = False
 
-    def rtr_logout(self):
-        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] in AllowedResponses:
-            return True
-        else:
-            return False
+        return error_checks
 
-    def test_RTR_ListScripts(self):
-        assert self.serviceRTR_ListScripts() is True
+    def test_list_scripts(self):
+        assert self.rtra_list_scripts() is True
 
-    def test_RTR_ListPut_Files(self):
-        assert self.serviceRTR_ListPut_Files() is True
+    def test_list_put_files(self):
+        assert self.rtra_list_put_files() is True
 
-    def test_Logout(self):
-        assert self.rtr_logout() is True
+    def test_logout(self):
+        """Pytest harness hook"""
+        assert auth.credential_logout(falcon) is True
 
-    def test_Errors(self):
-        assert self.serviceRTR_GenerateErrors() is True
+    def test_all_code_paths(self):
+        """Pytest harness hook"""
+        assert self.rtra_test_all_code_paths() is True

--- a/tests/test_real_time_response_admin.py
+++ b/tests/test_real_time_response_admin.py
@@ -4,6 +4,7 @@ test_real_time_response_admin.py - This class tests the real_time_response_admin
 import datetime
 import os
 import sys
+import json
 # Authentication via the test_authorization.py
 from tests import test_authorization as Authorization
 # Import our sibling src folder into the path
@@ -16,13 +17,44 @@ auth.getConfig()
 falcon = FalconRTR(creds={"client_id": auth.config["falcon_client_id"],
                           "client_secret": auth.config["falcon_client_secret"]
                           })
-AllowedResponses = [200, 201, 400, 404, 429]
+AllowedResponses = [200, 201, 202, 400, 404, 429]
 
 
 class TestRTR:
     """RTR Admin test harness"""
     @staticmethod
-    def rtra_test_all_code_paths():
+    def rtra_retrieve_script_id(script_name: str):
+        """Retrieve a script ID by name"""
+        found_id = "1234567890"  # Force an error if we can't find it
+        scripts = falcon.list_scripts()
+        for resource in scripts["body"]["resources"]:
+            script = falcon.get_scripts(ids=resource)
+            for file in script["body"]["resources"]:
+                if "name" in file:
+                    if file["name"] == script_name:
+                        found_id = file["id"]
+
+        return found_id
+
+    @staticmethod
+    def rtra_retrieve_file_id(file_name: str):
+        """Retrieve a script ID by name"""
+        found_id = "1234567890"  # Force an error if we can't find it
+        files = falcon.list_put_files()
+        for resource in files["body"]["resources"]:
+            file = falcon.get_put_files(ids=resource)
+            for item in file["body"]["resources"]:
+                if "name" in item:
+                    if item["name"] == file_name:
+                        found_id = item["id"]
+
+        return found_id
+
+    def rtra_create_updated_payload(self, file_name: str, orig_payload: dict):
+        orig_payload["id"] = self.rtra_retrieve_script_id(file_name)
+        return orig_payload
+
+    def rtra_test_all_code_paths(self):
         """Tests all code paths, accepts all errors except 500"""
         upload_file = "tests/testfile.png"
         fmt = '%Y-%m-%d %H:%M:%S'
@@ -32,30 +64,45 @@ class TestRTR:
         jdate = sdtdate.tm_yday
         jdate = "{}{}".format(stddate.replace("-", "").replace(":", "").replace(" ", ""), jdate)
         upload_filename = "%s_testfile.png" % jdate
+        script_filename = "%s_testscript" % jdate
 
         file_payload = {'name': upload_filename, 'description': 'FalconPy Unit Testing'}
         files_detail = [
             ('file', ('testfile.png', open(upload_file, 'rb'), 'image/png'))
         ]
-
+        script_payload = {
+            'name': script_filename,
+            'description': 'FalconPy Unit Testing',
+            'permission_type': 'private',
+            'content': 'Write-Output "This is a processing script."'
+        }
+        new_script_payload = json.loads(json.dumps(script_payload))
+        new_script_payload["content"] = 'Write-Output "This is an updated processing script."'
+        script_detail = [('file', (f"{script_filename}", 'application/script'))]
         error_checks = True
         tests = {
-            "batch_admin_cmd": falcon.BatchAdminCmd(body={})["status_code"],
-            "check_admin_command_status": falcon.RTR_CheckAdminCommandStatus(parameters={})["status_code"],
-            "execute_admin_command": falcon.RTR_ExecuteAdminCommand(body={})["status_code"],
-            "get_put_files": falcon.RTR_GetPut_Files(ids='12345678')["status_code"],
+            "batch_admin_cmd": falcon.BatchAdminCmd(body={})["status_code"],                                    # 400
+            "check_admin_command_status": falcon.RTR_CheckAdminCommandStatus(parameters={})["status_code"],     # 400
+            "execute_admin_command": falcon.RTR_ExecuteAdminCommand(body={})["status_code"],                    # 400
             "create_put_files": falcon.RTR_CreatePut_Files(data=file_payload, files=files_detail)["status_code"],
-            "delete_put_files": falcon.RTR_DeletePut_Files(ids='12345678')["status_code"],
-            "get_scripts": falcon.RTR_GetScripts(ids='12345678')["status_code"],
-            "create_scripts": falcon.RTR_CreateScripts(data={}, files=[])["status_code"],
-            "delete_scripts": falcon.RTR_DeleteScripts(ids='12345678')["status_code"],
-            "update_scripts": falcon.RTR_UpdateScripts(data={}, files=[])["status_code"],
+            "get_put_files": falcon.RTR_GetPut_Files(ids=self.rtra_retrieve_file_id(file_name=upload_filename))["status_code"],
+            "delete_put_files": falcon.RTR_DeletePut_Files(
+                ids=self.rtra_retrieve_file_id(file_name=upload_filename)
+                )["status_code"],
+            "create_scripts": falcon.RTR_CreateScripts(data=script_payload, files=script_detail)["status_code"],
+            "get_scripts": falcon.RTR_GetScripts(ids=self.rtra_retrieve_script_id(script_filename))["status_code"],
+            "update_scripts": falcon.RTR_UpdateScripts(
+                data=self.rtra_create_updated_payload(script_filename, new_script_payload), files=script_detail
+                )["status_code"],
+            "delete_scripts": falcon.RTR_DeleteScripts(ids=self.rtra_retrieve_script_id(script_filename))["status_code"],
             "list_put_files": falcon.RTR_ListPut_Files()["status_code"],
             "list_scripts": falcon.RTR_ListScripts()["status_code"]
         }
         for key in tests:
             if tests[key] not in AllowedResponses:
                 error_checks = False
+
+            # print(f"{key} processed with a {tests[key]} response")
 
         return error_checks
 

--- a/tests/test_real_time_response_admin.py
+++ b/tests/test_real_time_response_admin.py
@@ -69,10 +69,13 @@ class TestRTR:
         """Pytest harness hook"""
         assert bool(falcon.RTR_ListPut_Files(parameters={"limit": 1})["status_code"] in AllowedResponses) is True
 
-    def test_logout(self):
-        """Pytest harness hook"""
-        assert auth.credential_logout(falcon) is True
-
     def test_all_code_paths(self):
         """Pytest harness hook"""
         assert self.rtra_test_all_code_paths() is True
+
+    @staticmethod
+    def test_logout():
+        """Pytest harness hook"""
+        assert bool(falcon.auth_object.revoke(
+            falcon.auth_object.token()["body"]["access_token"]
+            )["status_code"] in [200, 201]) is True

--- a/tests/test_real_time_response_admin.py
+++ b/tests/test_real_time_response_admin.py
@@ -1,7 +1,7 @@
-# test_real_time_response_admin.py
-# This class tests the real_time_response_admin service class
+"""
+test_real_time_response_admin.py - This class tests the real_time_response_admin service class
+"""
 import datetime
-import requests
 import os
 import sys
 # Authentication via the test_authorization.py
@@ -20,20 +20,10 @@ AllowedResponses = [200, 201, 400, 404, 429]
 
 
 class TestRTR:
-
-    def rtra_list_put_files(self):
-        if falcon.RTR_ListPut_Files(parameters={"limit": 1})["status_code"] in AllowedResponses:
-            return True
-        else:
-            return False
-
-    def rtra_list_scripts(self):
-        if falcon.RTR_ListScripts(parameters={"limit": 1})["status_code"] in AllowedResponses:
-            return True
-        else:
-            return False
-
-    def rtra_test_all_code_paths(self):
+    """RTR Admin test harness"""
+    @staticmethod
+    def rtra_test_all_code_paths():
+        """Tests all code paths, accepts all errors except 500"""
         upload_file = "tests/testfile.png"
         fmt = '%Y-%m-%d %H:%M:%S'
         stddate = datetime.datetime.now().strftime(fmt)
@@ -69,13 +59,18 @@ class TestRTR:
 
         return error_checks
 
-    def test_list_scripts(self):
-        assert self.rtra_list_scripts() is True
+    @staticmethod
+    def test_list_scripts():
+        """Pytest harness hook"""
+        assert bool(falcon.RTR_ListScripts(parameters={"limit": 1})["status_code"] in AllowedResponses) is True
 
-    def test_list_put_files(self):
-        assert self.rtra_list_put_files() is True
+    @staticmethod
+    def test_list_put_files():
+        """Pytest harness hook"""
+        assert bool(falcon.RTR_ListPut_Files(parameters={"limit": 1})["status_code"] in AllowedResponses) is True
 
-    def test_logout(self):
+    @staticmethod
+    def test_logout():
         """Pytest harness hook"""
         assert auth.credential_logout(falcon) is True
 

--- a/tests/test_real_time_response_admin.py
+++ b/tests/test_real_time_response_admin.py
@@ -20,33 +20,35 @@ falcon = FalconRTR(creds={"client_id": auth.config["falcon_client_id"],
 AllowedResponses = [200, 201, 202, 400, 404, 429]
 
 
-class TestRTR:
-    """RTR Admin test harness"""
+class TestRTRAdmin:
+    """
+    Real Time Response Admin Test Harness
+    """
     @staticmethod
     def rtra_retrieve_script_id(script_name: str):
-        """Retrieve a script ID by name"""
+        """
+        Helper to retrieve a script ID by name
+        """
         found_id = "1234567890"  # Force an error if we can't find it
-        scripts = falcon.list_scripts()
-        for resource in scripts["body"]["resources"]:
-            script = falcon.get_scripts(ids=resource)
-            for file in script["body"]["resources"]:
-                if "name" in file:
-                    if file["name"] == script_name:
-                        found_id = file["id"]
+        script = falcon.get_scripts(ids=falcon.list_scripts()["body"]["resources"])
+        for file in script["body"]["resources"]:
+            if "name" in file:
+                if file["name"] == script_name:
+                    found_id = file["id"]
 
         return found_id
 
     @staticmethod
     def rtra_retrieve_file_id(file_name: str):
-        """Retrieve a script ID by name"""
+        """
+        Helper to retrieve a put file ID by name
+        """
         found_id = "1234567890"  # Force an error if we can't find it
-        files = falcon.list_put_files()
-        for resource in files["body"]["resources"]:
-            file = falcon.get_put_files(ids=resource)
-            for item in file["body"]["resources"]:
-                if "name" in item:
-                    if item["name"] == file_name:
-                        found_id = item["id"]
+        file = falcon.get_put_files(ids=falcon.list_put_files()["body"]["resources"])
+        for item in file["body"]["resources"]:
+            if "name" in item:
+                if item["name"] == file_name:
+                    found_id = item["id"]
 
         return found_id
 
@@ -55,7 +57,9 @@ class TestRTR:
         return orig_payload
 
     def rtra_test_all_code_paths(self):
-        """Tests all code paths, accepts all errors except 500"""
+        """
+        Tests all code paths, accepts all errors except 500
+        """
         upload_file = "tests/testfile.png"
         fmt = '%Y-%m-%d %H:%M:%S'
         stddate = datetime.datetime.now().strftime(fmt)
@@ -85,12 +89,10 @@ class TestRTR:
             "check_admin_command_status": falcon.RTR_CheckAdminCommandStatus(parameters={})["status_code"],     # 400
             "execute_admin_command": falcon.RTR_ExecuteAdminCommand(body={})["status_code"],                    # 400
             "create_put_files": falcon.RTR_CreatePut_Files(data=file_payload, files=files_detail)["status_code"],
-            "get_put_files": falcon.RTR_GetPut_Files(ids=self.rtra_retrieve_file_id(file_name=upload_filename))["status_code"],
             "delete_put_files": falcon.RTR_DeletePut_Files(
                 ids=self.rtra_retrieve_file_id(file_name=upload_filename)
                 )["status_code"],
             "create_scripts": falcon.RTR_CreateScripts(data=script_payload, files=script_detail)["status_code"],
-            "get_scripts": falcon.RTR_GetScripts(ids=self.rtra_retrieve_script_id(script_filename))["status_code"],
             "update_scripts": falcon.RTR_UpdateScripts(
                 data=self.rtra_create_updated_payload(script_filename, new_script_payload), files=script_detail
                 )["status_code"],
@@ -106,23 +108,17 @@ class TestRTR:
 
         return error_checks
 
-    @staticmethod
-    def test_list_scripts():
-        """Pytest harness hook"""
-        assert bool(falcon.RTR_ListScripts(parameters={"limit": 1})["status_code"] in AllowedResponses) is True
-
-    @staticmethod
-    def test_list_put_files():
-        """Pytest harness hook"""
-        assert bool(falcon.RTR_ListPut_Files(parameters={"limit": 1})["status_code"] in AllowedResponses) is True
-
     def test_all_code_paths(self):
-        """Pytest harness hook"""
+        """
+        Pytest harness hook - Singular test will execute every statement in every method within the class
+        """
         assert self.rtra_test_all_code_paths() is True
 
     @staticmethod
     def test_logout():
-        """Pytest harness hook"""
+        """
+        Pytest harness hook
+        """
         assert bool(falcon.auth_object.revoke(
             falcon.auth_object.token()["body"]["access_token"]
             )["status_code"] in [200, 201]) is True

--- a/tests/test_real_time_response_admin.py
+++ b/tests/test_real_time_response_admin.py
@@ -14,7 +14,7 @@ auth = Authorization.TestAuthorization()
 auth.getConfig()
 falcon = FalconRTR(creds={"client_id": auth.config["falcon_client_id"],
                           "client_secret": auth.config["falcon_client_secret"]})
-AllowedResponses = [200, 429]  # Adding rate-limiting as an allowed response for now
+AllowedResponses = [200, 201, 429]  # Adding rate-limiting as an allowed response for now
 
 
 class TestRTR:
@@ -55,7 +55,7 @@ class TestRTR:
         return errorChecks
 
     def rtr_logout(self):
-        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] == 200:
+        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] in AllowedResponses:
             return True
         else:
             return False

--- a/tests/test_real_time_response_admin.py
+++ b/tests/test_real_time_response_admin.py
@@ -69,8 +69,7 @@ class TestRTR:
         """Pytest harness hook"""
         assert bool(falcon.RTR_ListPut_Files(parameters={"limit": 1})["status_code"] in AllowedResponses) is True
 
-    @staticmethod
-    def test_logout():
+    def test_logout(self):
         """Pytest harness hook"""
         assert auth.credential_logout(falcon) is True
 

--- a/tests/test_sample_uploads.py
+++ b/tests/test_sample_uploads.py
@@ -17,6 +17,7 @@ auth = Authorization.TestAuthorization()
 auth.getConfig()
 falcon = Sample_Uploads(creds={"client_id": auth.config["falcon_client_id"],
                                "client_secret": auth.config["falcon_client_secret"]})
+AllowedResponses = [200, 201, 429]
 
 
 class TestSampleUploads:
@@ -89,7 +90,7 @@ class TestSampleUploads:
         return errorChecks
 
     def sample_logout(self):
-        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] == 200:
+        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] in AllowedResponses:
             return True
         else:
             return False

--- a/tests/test_uber_api_complete.py
+++ b/tests/test_uber_api_complete.py
@@ -99,7 +99,7 @@ class TestUber:
         response = falcon.command('UploadSampleV3', file_name=SOURCE, data=PAYLOAD, content_type="application/octet-stream")
         try:
             sha = response["body"]["resources"][0]["sha256"]
-            response = falcon.command("GetSampleV3", parameters={}, ids=sha)
+            response = falcon.command("GetSampleV3", ids=sha)
             try:
                 open(TARGET, 'wb').write(response)
             except TypeError:

--- a/tests/test_zero_trust_assessment.py
+++ b/tests/test_zero_trust_assessment.py
@@ -13,6 +13,7 @@ auth = Authorization.TestAuthorization()
 auth.getConfig()
 falcon = FalconZTA(creds={"client_id": auth.config["falcon_client_id"],
                           "client_secret": auth.config["falcon_client_secret"]})
+AllowedResponses = [200, 201, 429]
 
 
 class TestZeroTrustAssessment:
@@ -25,7 +26,7 @@ class TestZeroTrustAssessment:
         return errorChecks
 
     def zta_logout(self):
-        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] == 200:
+        if falcon.auth_object.revoke(falcon.auth_object.token()["body"]["access_token"])["status_code"] in AllowedResponses:
             return True
         else:
             return False


### PR DESCRIPTION
# FalconPy v0.5.7
Pull Request general description should go here.
> Please fill out all values and then remove any help text before submitting your PR.
> Refer to [this PR](https://github.com/CrowdStrike/falconpy/pull/67) as a reference example!

- [x] Enhancement
- [x] Bug fixes 
- [x] Potential Breaking Change
- [x] Updated unit tests

#### Unit test coverage
```shell
COVERAGE RESULTS PENDING
```

#### Bandit analysis
```shell
BANDIT ANALYSIS PENDING
```

## Added features and functionality
+ Refactored Events Streams Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #248. `event_streams.py`
+ Refactored Custom IOA Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #258. `custom_ioa.py`
+ Refactored Falcon X Sandbox Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #259. `falconx_sandbox.py`
+ Refactored Firewall Management Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #257. `firewall_management.py`
+ Refactored Intel Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #264. `intel.py`
+ Refactored Real Time Response Admin Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #256. `real_time_response_admin.py`
+ Refactored Sample Uploads Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #255. `sample_uploads.py`
+ Refactored Zero Trust Assessment Service Class to the latest pattern (rev 3), aligns syntax to PEP8. Closes #260. `zero_trust_assessment.py`

## Issues resolved
+ Bug fix: Resolved HTTP status code 415 on calls to refreshActiveStreamSession (refresh_active_stream). Closes #247. `event_streams.py`
+ Bug fix: Resolved header pollution issue within Falcon X Sandbox Service Class. Closes #250. `falconx_sandbox.py`
+ Bug fix: Resolved header pollution issue within Firewall Management Service Class. Closes #252. `firewall_management.py`
+ Bug fix: Resolved header pollution issue within Custom IOA Service Class. Closes #253. `custom_ioa.py`
+ Bug fix: Resolved header pollution issue within Sample Uploads Service Class. Closes #254. `sample_uploads.py`
+ Bug fix: Resolved HTTP status code 500 error on calls to RTR_CreatePut_Files (create_put_files). Closes #261. `real_time_response_admin.py`
+ Bug fix: Resolved HTTP status code 400 or 500 error on calls to RTR_UpdateScripts (update_scripts) and calls to RTR_CreateScripts (create_scripts). Closes #262. `real_time_response_admin.py`
+ Bug fix: Updated force_default helper function to drop all but the first argument passed to the method, forcing Service Classes to support keywords only. Closes #263. `_util.py`
> Potential __*breaking change*__: Developers must use keywords, __not arguments__, when specifying parameters provided to Service Class methods.
#### Example
```python
from falconpy.hosts import Hosts
falcon = Hosts(creds={"client_id": CLIENT_ID_HERE, "client_secret": CLIENT_SECRET_HERE})

result = falcon.GetDeviceDetails(ids="12345"))   # This command will work
print(result)

bad_result = falcon.GetDeviceDetails("12345")    # This command will fail with the API complaining
print(bad_result)                                # that the "ids" parameter is not present.
```

+ Related to #263: Updated Uber class to no longer leverage the force_default helper, allowing users to still use the first argument to specify the action to be performed. `api_complete.py`
> Note: This functionality _only_ works when using the Uber class, and _only_ with the __action__ parameter.

## Other
+ Initial refactoring of unit test harnesses for service classes detailed above.
    - `test_cloud_connect_aws.py`
    - `test_custom_ioa.py`
    - `test_event_streams.py`
    - `test_falconx_sandbox.py`
    - `test_intel.py`
    - `test_firewall_management.py`
    - `test_real_time_response_admin.py` (Updated to cover additional API operations)
    - `test_sample_uploads.py`
    - `zero_trust_assessment.py`
+ Minor adjustment to Uber class unit tests to better demonstrate proper method usage. `test_uber_api_complete.py`
+ Initial refactoring of unit tests to support US-2 / Gov base URL testing.
    - `test_authorization.py`

