### PR TITLE
Typo in Firewall Management service class, update_rule_group method

### DIFF
--- a/src/falconpy/firewall_management.py
+++ b/src/falconpy/firewall_management.py
@@ -237,7 +237,7 @@ class FirewallManagement(ServiceClass):
         return process_service_request(
             calling_object=self,
             endpoints=Endpoints,
-            operation_id="create_rule_group",
+            operation_id="update_rule_group",
             body=body,
             params=parameters,
             keywords=kwargs,


### PR DESCRIPTION
Resolves a typo in the Firewall Management service class, update_rule_group method.

*Appending to 0.6.2 release, introduced with the v0.6.0 pattern change.*

- [x] Bug fixes 
