### PR TITLE
Updated sample to use python dict get() method to avoid KeyNotFound e…

### DIFF
--- a/samples/hosts/sensor_versions_by_hostname.py
+++ b/samples/hosts/sensor_versions_by_hostname.py
@@ -26,8 +26,8 @@ def device_detail(aids: list):
     # return just the aid and agent version
     for device in result["body"]["resources"]:
         res = {}
-        res["hostname"] = device["hostname"]
-        res["agent_version"] = device["agent_version"]
+        res["hostname"] = device.get("hostname", None)
+        res["agent_version"] = device.get("agent_version", None)
         devices.append(res)
     return devices
 


### PR DESCRIPTION
This update resolves an issue within the sensor_versions_by_hostname sample.

- [x] Bug fixes 

## Issues resolved
+ Bug fix: updated to use python dict `get()` method to return None instead of a `KeyNotFound` exception

