### PR TITLE
Repo metadata additions

### DIFF
--- a/.cc-metadata.yml
+++ b/.cc-metadata.yml
@@ -1,0 +1,6 @@
+    # Whether this GitHub repo is for a CC-led engineering project
+    engineering_project: true
+    # All technologies used
+    technologies: Python, CrowdStrike
+    # Whether this repository should be featured on the CC Open Source site's "Projects" page
+    featured: true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @jshcodes @crowdstrikedcs

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,28 @@
+# Support
+FalconPy is an open source project, not a formal CrowdStrike product, to assist developers implement CrowdStrike's APIs within their applications. As such it carries no formal support, expressed or implied.
+
+:fire: **Is something not working as expected?** :fire:<br/>
+GitHub Issues are used to report bugs. Submit a ticket here: 
+[https://github.com/CrowdStrike/falconpy/issues/new/choose](https://github.com/CrowdStrike/falconpy/issues/new/choose)
+
+## Community Forums
+GitHub Discussions provide the community with means to communicate. There are four discussion categories:
+  * :speech_balloon: [**General**](https://github.com/CrowdStrike/falconpy/discussions?discussions_q=category%3AGeneral): Catch all for general discussions.
+  * :bulb: [**Ideas**](https://github.com/CrowdStrike/falconpy/discussions?discussions_q=category%3AIdeas): Have a suggestion for a feature request? Is there something the community or project could improve upon? Let us know here.
+  * :pray: [**Q&A**](https://github.com/CrowdStrike/falconpy/discussions?discussions_q=category%3AQ%26A): Have a question about how to accomplish something? A usability question? Submit them here!
+  * :raised_hands: [**Show and Tell**](https://github.com/CrowdStrike/falconpy/discussions?discussions_q=category%3A%22Show+and+tell%22): Share with the community what you're up to! Perhaps this is letting everyone know about your upcoming conference talk, sharing a project that has embedded FalconPy, or your recent blog.
+
+# Documentation
+Extended FalconPy project documentation is available via our [wiki](https://github.com/CrowdStrike/falconpy/wiki) or at [falconpy.io](https://falconpy.io).
+This content is updated as part of our release cycle.
+
+# Contributing
+As our current [contributor list](https://github.com/CrowdStrike/falconpy/blob/jshcodes-repo-additions/AUTHORS.md#contributors) demonstrates, there are *many* ways you can contribute to the FalconPy project!
+  * ***Providing feedback*** by opening a GitHub ticket. Even a fly-by "Hey, this worked!" is appreciated and helps validate approaches. Ideas on improving the project are most welcome.
+  * ***Documenting, blogging, or creating videos***, of how you've used FalconPy! This type of content is *invaluable* and helps communities grow. Open a pull request for inclusion in the [Documentation and Collateral](https://github.com/CrowdStrike/falconpy#documentation-and-collateral) section.
+  * ***Fix a bug or implement a new feature***. Check out our [open issues on GitHub](https://github.com/CrowdStrike/falconpy/issues) for inspiration.
+  * ***Review pull requests*** by going through the queue of [open pull requests on GitHub](https://github.com/CrowdStrike/falconpy/pulls) and giving feedback to the authors.
+
+  > Review [CONTRIBUTING.md](https://github.com/CrowdStrike/falconpy/blob/main/CONTRIBUTING.md) for more details regarding contributing to the FalconPy project.
+
+Open to do something else but not sure where to start? Try [opening an issue](https://github.com/CrowdStrike/falconpy/issues/new) or posting a topic on our [discussion board](https://github.com/CrowdStrike/falconpy/discussions) to introduce yourself and your interests. We look forward to chatting with you!


### PR DESCRIPTION
This update implements three standard repo files.
- `.cc-metadata.yml` - Creative Commons standard metadata.
- `.github/CODEOWNERS` - Code ownership definitions.
- `SUPPORT.md` - Support options descriptions.