### PR TITLE
Fix broken link on Samples README

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -106,7 +106,7 @@ _Coming Soon_
 ### Spotlight Vulnerabilities
 | Service Class | Uber Class |
 | :--- | :--- |
-| [Identify hosts with vulnerabilities by CVE](find_hosts_by_cve.py) | |
+| [Identify hosts with vulnerabilities by CVE](spotlight#identify-hosts-with-vulnerabilities-by-cve) | |
 
 
 ## Suggestions


### PR DESCRIPTION
# Fix Samples README broken link
Resolves a broken link on the README for the Samples folder.

- [x] Documentation

## Issues resolved
+ Broken link fix: Resolves broken link for Spotlight Vulnerabilities sample.
    - `samples/README.md`