### PR TITLE
Fix of refresh_active_stream to support updating partition 0

### DIFF
--- a/src/falconpy/_util.py
+++ b/src/falconpy/_util.py
@@ -380,7 +380,7 @@ def process_service_request(calling_object: object,
     target_url = f"{calling_object.base_url}{target_endpoint[2]}"
     target_method = target_endpoint[1]
     passed_partition = kwargs.get("partition", None)
-    if passed_partition:
+    if isinstance(passed_partition, int):
         target_url = target_url.format(str(passed_partition))
     passed_distinct_field = kwargs.get("distinct_field", None)
     if passed_distinct_field:

--- a/src/falconpy/_util.py
+++ b/src/falconpy/_util.py
@@ -380,7 +380,7 @@ def process_service_request(calling_object: object,
     target_url = f"{calling_object.base_url}{target_endpoint[2]}"
     target_method = target_endpoint[1]
     passed_partition = kwargs.get("partition", None)
-    if isinstance(passed_partition, int):
+    if passed_partition or isinstance(passed_partition, int):
         target_url = target_url.format(str(passed_partition))
     passed_distinct_field = kwargs.get("distinct_field", None)
     if passed_distinct_field:

--- a/tests/test_event_streams.py
+++ b/tests/test_event_streams.py
@@ -48,7 +48,7 @@ class TestEventStreams:
         with stream:
             result = falcon.refreshActiveStreamSession(app_id=f"{APP_ID}",
                                                        action_name="refresh_active_stream_session",
-                                                       partition="0"
+                                                       partition=0
                                                        )
             return bool(result["status_code"] in AllowedResponses)
 


### PR DESCRIPTION
## Fix of refresh_active_stream to support updating partition 0
Updated _util:process_service_request to fix the validation if partition was set, caused invalid url for partition 0 as would return false even when set and making the url not being formatted properly.

Quite new to PR's ( and unit tests in general ) - let me know if I can do anything to improve and ease your job. 

- [X] Bug fixes 

#### Unit test coverage

Note a lot of tests failed with the description of `AttributeError: 'TestAuthorization' object has no attribute 'authorization'`. Can't find anything regarding unit test that should be done to avoid this?

```shell
Name                                                             Stmts   Miss  Cover
------------------------------------------------------------------------------------
src/falconpy/__init__.py                                            62      0   100%
src/falconpy/_base_url.py                                            7      0   100%
src/falconpy/_endpoint/__init__.py                                 117      0   100%
src/falconpy/_endpoint/_cloud_connect_aws.py                         1      0   100%
src/falconpy/_endpoint/_cspm_registration.py                         1      0   100%
src/falconpy/_endpoint/_custom_ioa.py                                1      0   100%
src/falconpy/_endpoint/_d4c_registration.py                          1      0   100%
src/falconpy/_endpoint/_detects.py                                   1      0   100%
src/falconpy/_endpoint/_device_control_policies.py                   1      0   100%
src/falconpy/_endpoint/_discover.py                                  1      0   100%
src/falconpy/_endpoint/_event_streams.py                             1      0   100%
src/falconpy/_endpoint/_falcon_complete_dashboard.py                 1      0   100%
src/falconpy/_endpoint/_falcon_container.py                          1      0   100%
src/falconpy/_endpoint/_falconx_sandbox.py                           1      0   100%
src/falconpy/_endpoint/_filevantage.py                               1      0   100%
src/falconpy/_endpoint/_firewall_management.py                       1      0   100%
src/falconpy/_endpoint/_firewall_policies.py                         1      0   100%
src/falconpy/_endpoint/_host_group.py                                1      0   100%
src/falconpy/_endpoint/_hosts.py                                     1      0   100%
src/falconpy/_endpoint/_identity_protection.py                       1      0   100%
src/falconpy/_endpoint/_incidents.py                                 1      0   100%
src/falconpy/_endpoint/_installation_tokens.py                       1      0   100%
src/falconpy/_endpoint/_intel.py                                     1      0   100%
src/falconpy/_endpoint/_ioa_exclusions.py                            1      0   100%
src/falconpy/_endpoint/_ioc.py                                       1      0   100%
src/falconpy/_endpoint/_iocs.py                                      1      0   100%
src/falconpy/_endpoint/_kubernetes_protection.py                     1      0   100%
src/falconpy/_endpoint/_malquery.py                                  1      0   100%
src/falconpy/_endpoint/_message_center.py                            1      0   100%
src/falconpy/_endpoint/_ml_exclusions.py                             1      0   100%
src/falconpy/_endpoint/_mssp.py                                      1      0   100%
src/falconpy/_endpoint/_oauth2.py                                    1      0   100%
src/falconpy/_endpoint/_overwatch_dashboard.py                       1      0   100%
src/falconpy/_endpoint/_prevention_policies.py                       1      0   100%
src/falconpy/_endpoint/_quarantine.py                                1      0   100%
src/falconpy/_endpoint/_quick_scan.py                                1      0   100%
src/falconpy/_endpoint/_real_time_response.py                        1      0   100%
src/falconpy/_endpoint/_real_time_response_admin.py                  1      0   100%
src/falconpy/_endpoint/_recon.py                                     1      0   100%
src/falconpy/_endpoint/_report_executions.py                         1      0   100%
src/falconpy/_endpoint/_response_policies.py                         1      0   100%
src/falconpy/_endpoint/_sample_uploads.py                            1      0   100%
src/falconpy/_endpoint/_scheduled_reports.py                         1      0   100%
src/falconpy/_endpoint/_sensor_download.py                           1      0   100%
src/falconpy/_endpoint/_sensor_update_policies.py                    1      0   100%
src/falconpy/_endpoint/_sensor_visibility_exclusions.py              1      0   100%
src/falconpy/_endpoint/_spotlight_vulnerabilities.py                 1      0   100%
src/falconpy/_endpoint/_user_management.py                           1      0   100%
src/falconpy/_endpoint/_zero_trust_assessment.py                     1      0   100%
src/falconpy/_endpoint/deprecated/__init__.py                       22      0   100%
src/falconpy/_endpoint/deprecated/_custom_ioa.py                     1      0   100%
src/falconpy/_endpoint/deprecated/_discover.py                       1      0   100%
src/falconpy/_endpoint/deprecated/_firewall_management.py            1      0   100%
src/falconpy/_endpoint/deprecated/_identity_protection.py            1      0   100%
src/falconpy/_endpoint/deprecated/_installation_tokens.py            1      0   100%
src/falconpy/_endpoint/deprecated/_ioc.py                            1      0   100%
src/falconpy/_endpoint/deprecated/_iocs.py                           1      0   100%
src/falconpy/_endpoint/deprecated/_real_time_response.py             1      0   100%
src/falconpy/_endpoint/deprecated/_real_time_response_admin.py       1      0   100%
src/falconpy/_endpoint/deprecated/_report_executions.py              1      0   100%
src/falconpy/_endpoint/deprecated/_scheduled_reports.py              1      0   100%
src/falconpy/_payload/__init__.py                                   24      0   100%
src/falconpy/_payload/_cloud_connect_aws.py                         22     21     5%
src/falconpy/_payload/_cspm_registration.py                         40     37     8%
src/falconpy/_payload/_d4c_registration.py                          10      9    10%
src/falconpy/_payload/_detects.py                                   13     12     8%
src/falconpy/_payload/_device_control_policy.py                     13     12     8%
src/falconpy/_payload/_falconx.py                                   25     24     4%
src/falconpy/_payload/_firewall.py                                  65     61     6%
src/falconpy/_payload/_generic.py                                   65     61     6%
src/falconpy/_payload/_host_group.py                                30     28     7%
src/falconpy/_payload/_ioa.py                                       29     27     7%
src/falconpy/_payload/_ioc.py                                       36     33     8%
src/falconpy/_payload/_malquery.py                                  56     52     7%
src/falconpy/_payload/_message_center.py                            22     20     9%
src/falconpy/_payload/_mssp.py                                      15     14     7%
src/falconpy/_payload/_prevention_policy.py                         19     18     5%
src/falconpy/_payload/_real_time_response.py                        27     25     7%
src/falconpy/_payload/_recon.py                                     72     66     8%
src/falconpy/_payload/_reports.py                                   18     17     6%
src/falconpy/_payload/_response_policy.py                           19     18     5%
src/falconpy/_payload/_sensor_update_policy.py                      24     23     4%
src/falconpy/_result.py                                              8      5    38%
src/falconpy/_service_class.py                                      73     67     8%
src/falconpy/_util.py                                              184    152    17%
src/falconpy/_version.py                                            10      0   100%
src/falconpy/api_complete.py                                       113     99    12%
src/falconpy/cloud_connect_aws.py                                   47     15    68%
src/falconpy/cspm_registration.py                                  118     51    57%
src/falconpy/custom_ioa.py                                          85     31    64%
src/falconpy/d4c_registration.py                                    47     17    64%
src/falconpy/detects.py                                             28     10    64%
src/falconpy/device_control_policies.py                             66     29    56%
src/falconpy/discover.py                                            10      2    80%
src/falconpy/event_streams.py                                       19      8    58%
src/falconpy/falcon_complete_dashboard.py                           76     28    63%
src/falconpy/falcon_container.py                                     7      1    86%
src/falconpy/falconx_sandbox.py                                     67     24    64%
src/falconpy/filevantage.py                                         13      2    85%
src/falconpy/firewall_management.py                                 81     34    58%
src/falconpy/firewall_policies.py                                   68     29    57%
src/falconpy/host_group.py                                          58     23    60%
src/falconpy/hosts.py                                               65     36    45%
src/falconpy/identity_protection.py                                 12      4    67%
src/falconpy/incidents.py                                           37     14    62%
src/falconpy/installation_tokens.py                                 37     16    57%
src/falconpy/intel.py                                               63     16    75%
src/falconpy/ioa_exclusions.py                                      32     11    66%
src/falconpy/ioc.py                                                 49     14    71%
src/falconpy/iocs.py                                                39      9    77%
src/falconpy/kubernetes_protection.py                               49     16    67%
src/falconpy/malquery.py                                            49     17    65%
src/falconpy/message_center.py                                      74     28    62%
src/falconpy/ml_exclusions.py                                       34     13    62%
src/falconpy/mssp.py                                               130     50    62%
src/falconpy/oauth2.py                                              74     62    16%
src/falconpy/overwatch_dashboard.py                                 30      9    70%
src/falconpy/prevention_policy.py                                   59     22    63%
src/falconpy/quarantine.py                                          45     22    51%
src/falconpy/quick_scan.py                                          26      8    69%
src/falconpy/real_time_response.py                                 114     45    61%
src/falconpy/real_time_response_admin.py                            64     22    66%
src/falconpy/recon.py                                               97     33    66%
src/falconpy/report_executions.py                                   23      6    74%
src/falconpy/response_policies.py                                   58     22    62%
src/falconpy/sample_uploads.py                                      24      9    62%
src/falconpy/scheduled_reports.py                                   19      5    74%
src/falconpy/sensor_download.py                                     32     11    66%
src/falconpy/sensor_update_policy.py                               107     45    58%
src/falconpy/sensor_visibility_exclusions.py                        32     11    66%
src/falconpy/spotlight_vulnerabilities.py                           25      5    80%
src/falconpy/user_management.py                                     69     30    57%
src/falconpy/zero_trust_assessment.py                               12      2    83%
------------------------------------------------------------------------------------
TOTAL                                                             3667   1818    50%
```

#### Bandit analysis
```shell
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: None
[main]	INFO	running on Python 3.9.9
134 [0.. 50.. 100.. ]
Run started:2022-02-14 07:06:24.351983

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 34109
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0.0
		Low: 0.0
		Medium: 0.0
		High: 0.0
	Total issues (by confidence):
		Undefined: 0.0
		Low: 0.0
		Medium: 0.0
		High: 0.0
Files skipped (0):
```

## Issues resolved
+ Bug fix: there is no bug report on this, just encountered this myself when developing something around this.
If you're updating the partition 0 with `refresh_active_stream` you get thrown an error like this `{'code': 400, 'message': 'Invalid partition [-1] specified in request'}` due to the url being /{} in the last part and not /0.