### PR TITLE
stale_sensors.py - Added filtering by Grouping Tags with -g (--grouping) arg

### DIFF
--- a/samples/hosts/stale_sensors.py
+++ b/samples/hosts/stale_sensors.py
@@ -5,6 +5,7 @@ stale_sensors.py - Detects devices that haven't checked into
 REQUIRES: FalconPy v0.8.6+, tabulate
 
 - jshcodes@CrowdStrike, 09.01.21
+- Updated to support Grouping Tags, @rayheffer, 03.24.22
 """
 from datetime import datetime, timedelta, timezone
 from argparse import RawTextHelpFormatter

--- a/samples/hosts/stale_sensors.py
+++ b/samples/hosts/stale_sensors.py
@@ -147,8 +147,9 @@ def parse_host_detail(detail: dict, found: list):
     now = datetime.strptime(str(datetime.now(timezone.utc)), "%Y-%m-%d %H:%M:%S.%f%z")
     then = datetime.strptime(detail["last_seen"], "%Y-%m-%dT%H:%M:%S%z")
     distance = (now - then).days
-    tagname = detail.get("tags")
-    newtag = str(tagname)[1:-1]
+    # tagname = detail.get("tags")
+    tagname = detail.get("tags", "Not Found")
+    newtag = str(tagname)[2:-2]
         
     found.append([
         detail.get("hostname", "Unknown"),

--- a/samples/hosts/stale_sensors.py
+++ b/samples/hosts/stale_sensors.py
@@ -1,11 +1,11 @@
 """
-stale_sensors_tag.py  - Detects devices that haven't checked into
-                  CrowdStrike for a specified period of time.
+stale_sensors.py - Detects devices that haven't checked into
+                   CrowdStrike for a specified period of time.
 
 REQUIRES: FalconPy v0.8.6+, tabulate
 
 - jshcodes@CrowdStrike, 09.01.21
-- ray.heffer@crowdstrike.com, 03.29.22 - Added new argument for Grouping Tag (--grouping, -g)
+- ray.heffer@crowdstrike.com, 03.29.22 - Added new argument for Grouping Tags (--grouping, -g)
 """
 from datetime import datetime, timedelta, timezone
 from argparse import RawTextHelpFormatter


### PR DESCRIPTION
## Stale Sensors Update
Added support for Grouping Tags in stale_sensors.py

- [X] Enhancement
- [X] Code samples

## Bandit analysis

```shell
[main]	INFO	running on Python 3.9.9
Run started:2022-03-29 15:31:17.000859

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 191
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```

## Added features and functionality
+ Use -g (--grouping) argument to filter results with specified tag.
+ Example: `python3 stale_sensors.py -k $FALCON_CLIENT_ID -s $FALCON_CLIENT_SECRET -d 30 -g testtag`
