### PR TITLE
New Custom IOA Cloner sample, Sample updates, public-modules.sh enhancements

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -737,3 +737,4 @@ GetOnlineState
 FilesV
 GetScriptsV
 DataType
+Cloner

--- a/samples/README.md
+++ b/samples/README.md
@@ -30,6 +30,7 @@ The following samples are categorized by CrowdStrike Falcon API service collecti
 
 | Service Collection | Samples |
 | :--- | :--- |
+| [Custom IOA](#custom-ioa) | [Custom IOA Cloner](#custom-ioa-cloner) |
 | [Detects](#detects) | [Detects Advisor](#detects-advisor) |
 | [Event Streams](#event-streams) | [Send detections to AWS Security Hub](#send-detections-to-aws-security-hub) |
 | [Falcon Discover](#falcon-discover) | [List discovered hosts](#list-discovered-hosts) |
@@ -62,6 +63,26 @@ Provided examples are further categorized by the type of class used to interact 
 | [![MSSP Usage supported](https://img.shields.io/badge/-Supports%20MSSP-darkblue?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAYAAAAi2ky3AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpaIVBzuIOGSoDmJBVEQ3rUIRKoRaoVUHk5f+CE0akhQXR8G14ODPYtXBxVlXB1dBEPwBcXNzUnSREu9LCi1ifPB4H+e9c7jvXkColZhmtY0Cmm6bqURczGRXxNAruhAEMI1hmVnGrCQl4bu+7hHg512MZ/m/+3N1qzmLAQGReIYZpk28Tjy5aRuc94kjrCirxOfEIyYVSPzIdcXjN84FlwWeGTHTqTniCLFYaGGlhVnR1IgniKOqplO+kPFY5bzFWStVWKNO/sNwTl9e4jrtASSwgEVIEKGggg2UYCNGp06KhRTdx338/a5fIpdCrg0wcsyjDA2y6wefwe/eWvnxMS8pHAfaXxznYxAI7QL1quN8HztO/QQIPgNXetNfrgFTn6RXm1r0COjZBi6um5qyB1zuAH1PhmzKrsTnL+TzwPsZjSkL9N4Cnate3xr3OH0A0tSr5A1wcAgMFSh7zeffHa19+/dNo38/hq9yr+iELI0AAAAGYktHRAAAAAAAAPlDu38AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQflDAsTByz7Va2cAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAYBJREFUKM+lkjFIlVEYht/zn3sFkYYUyUnIRcemhCtCU6JQOLiIU+QeJEQg6BBIm0s4RBCBLjq5OEvgJC1uOniJhivesLx17/97/vO9b4NK4g25157hfHCGB773/cA0HZIEAKiMj+LWiOxljG/i96pnCFP58XHnrWX2+9cj0dYl9Yu2FE9/9rXrcAAgs2eSyiBfOe/XRD503h/CuffOubQVUXL+Jh9BllzBbyJJBgDclVkO4Kukd8zzkXJbeUljIldFTstsmSHM6S81ma2KfPKlFdkGAMY4wzx/bbXapMy21My+YizdKNq5mDzLkrxafSxySFKjSWX2oTmjKzz4vN0r2lOFcL/Q3V0/mX95ILMXTTGYVfaut/aP2+oCMAvnZgCcsF5fcR0dg65YHAdwB+QApADvu0AuOe/ftlJAD7Nsgmm6yBjDtfWORJZlNtFyo/lR5Z7MyheKA5ktSur7sTAHazSG27pehjAiaVfkN8b4XFIJ/wOzbOx07VNRUuHy7w98CzCcGPyWywAAAABJRU5ErkJggg==&style=for-the-badge)](https://falconpy.io/Usage/Authenticating-to-the-API.html#mssp-examples-hosts) | These samples support MSSP usage scenarios.
 
 
+## Custom IOA
+This category demonstrates using CrowdStrike's Custom IOA service collection.
+
+### Custom IOA Cloner
+The [Custom IOA Cloner](custom_ioa#custom-ioa-cloner) demonstrates displaying, deleting and cloning Custom IOA rule groups.
+
+[![Custom IOA](https://img.shields.io/badge/Service%20Class-Custom_IOA_Cloner-silver?style=for-the-badge&labelColor=red&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAYAAAAi2ky3AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpaIVBzuIOGSoDmJBVEQ3rUIRKoRaoVUHk5f+CE0akhQXR8G14ODPYtXBxVlXB1dBEPwBcXNzUnSREu9LCi1ifPB4H+e9c7jvXkColZhmtY0Cmm6bqURczGRXxNAruhAEMI1hmVnGrCQl4bu+7hHg512MZ/m/+3N1qzmLAQGReIYZpk28Tjy5aRuc94kjrCirxOfEIyYVSPzIdcXjN84FlwWeGTHTqTniCLFYaGGlhVnR1IgniKOqplO+kPFY5bzFWStVWKNO/sNwTl9e4jrtASSwgEVIEKGggg2UYCNGp06KhRTdx338/a5fIpdCrg0wcsyjDA2y6wefwe/eWvnxMS8pHAfaXxznYxAI7QL1quN8HztO/QQIPgNXetNfrgFTn6RXm1r0COjZBi6um5qyB1zuAH1PhmzKrsTnL+TzwPsZjSkL9N4Cnate3xr3OH0A0tSr5A1wcAgMFSh7zeffHa19+/dNo38/hq9yr+iELI0AAAAGYktHRAAAAAAAAPlDu38AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQflDAsTByz7Va2cAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAYBJREFUKM+lkjFIlVEYht/zn3sFkYYUyUnIRcemhCtCU6JQOLiIU+QeJEQg6BBIm0s4RBCBLjq5OEvgJC1uOniJhivesLx17/97/vO9b4NK4g25157hfHCGB773/cA0HZIEAKiMj+LWiOxljG/i96pnCFP58XHnrWX2+9cj0dYl9Yu2FE9/9rXrcAAgs2eSyiBfOe/XRD503h/CuffOubQVUXL+Jh9BllzBbyJJBgDclVkO4Kukd8zzkXJbeUljIldFTstsmSHM6S81ma2KfPKlFdkGAMY4wzx/bbXapMy21My+YizdKNq5mDzLkrxafSxySFKjSWX2oTmjKzz4vN0r2lOFcL/Q3V0/mX95ILMXTTGYVfaut/aP2+oCMAvnZgCcsF5fcR0dg65YHAdwB+QApADvu0AuOe/ftlJAD7Nsgmm6yBjDtfWORJZlNtFyo/lR5Z7MyheKA5ktSur7sTAHazSG27pehjAiaVfkN8b4XFIJ/wOzbOx07VNRUuHy7w98CzCcGPyWywAAAABJRU5ErkJggg==)](custom_ioa#custom-ioa-cloner)
+
+#### Custom IOA API operations discussed
+This sample demonstrates the following CrowdStrike Custom IOA API operations:
+
+| Operation | Description |
+| :--- | :--- |
+| [create_rule](https://www.falconpy.io/Service-Collections/Custom-IOA.html#create_rule) | Create a rule within a rule group. Returns the rule. |
+| [create_rule_groupMixin0](https://www.falconpy.io/Service-Collections/Custom-IOA.html#create_rule_groupmixin0) | Create a rule group for a platform with a name and an optional description. Returns the rule group. |
+| [delete_rule_groupsMixin0](https://www.falconpy.io/Service-Collections/Custom-IOA.html#delete_rule_groupsmixin0) | Delete rule groups by ID. |
+| [query_rule_groups_full](https://www.falconpy.io/Service-Collections/Custom-IOA.html#query_rule_groups_full) | Find all rule groups matching the query with optional filter. |
+
+---
+
 ## Detects
 The CrowdStrike Detects API service collection is the sole focus of this category.
 
@@ -71,7 +92,7 @@ The CrowdStrike Detects API service collection is the sole focus of this categor
 [![Detects](https://img.shields.io/badge/Service%20Class-Detects%20Advisor-silver?style=for-the-badge&labelColor=red&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAYAAAAi2ky3AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpaIVBzuIOGSoDmJBVEQ3rUIRKoRaoVUHk5f+CE0akhQXR8G14ODPYtXBxVlXB1dBEPwBcXNzUnSREu9LCi1ifPB4H+e9c7jvXkColZhmtY0Cmm6bqURczGRXxNAruhAEMI1hmVnGrCQl4bu+7hHg512MZ/m/+3N1qzmLAQGReIYZpk28Tjy5aRuc94kjrCirxOfEIyYVSPzIdcXjN84FlwWeGTHTqTniCLFYaGGlhVnR1IgniKOqplO+kPFY5bzFWStVWKNO/sNwTl9e4jrtASSwgEVIEKGggg2UYCNGp06KhRTdx338/a5fIpdCrg0wcsyjDA2y6wefwe/eWvnxMS8pHAfaXxznYxAI7QL1quN8HztO/QQIPgNXetNfrgFTn6RXm1r0COjZBi6um5qyB1zuAH1PhmzKrsTnL+TzwPsZjSkL9N4Cnate3xr3OH0A0tSr5A1wcAgMFSh7zeffHa19+/dNo38/hq9yr+iELI0AAAAGYktHRAAAAAAAAPlDu38AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQflDAsTByz7Va2cAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAYBJREFUKM+lkjFIlVEYht/zn3sFkYYUyUnIRcemhCtCU6JQOLiIU+QeJEQg6BBIm0s4RBCBLjq5OEvgJC1uOniJhivesLx17/97/vO9b4NK4g25157hfHCGB773/cA0HZIEAKiMj+LWiOxljG/i96pnCFP58XHnrWX2+9cj0dYl9Yu2FE9/9rXrcAAgs2eSyiBfOe/XRD503h/CuffOubQVUXL+Jh9BllzBbyJJBgDclVkO4Kukd8zzkXJbeUljIldFTstsmSHM6S81ma2KfPKlFdkGAMY4wzx/bbXapMy21My+YizdKNq5mDzLkrxafSxySFKjSWX2oTmjKzz4vN0r2lOFcL/Q3V0/mX95ILMXTTGYVfaut/aP2+oCMAvnZgCcsF5fcR0dg65YHAdwB+QApADvu0AuOe/ftlJAD7Nsgmm6yBjDtfWORJZlNtFyo/lR5Z7MyheKA5ktSur7sTAHazSG27pehjAiaVfkN8b4XFIJ/wOzbOx07VNRUuHy7w98CzCcGPyWywAAAABJRU5ErkJggg==)](detects#detects-advisor)
 
 #### Detects API operations discussed
-This sample demonstrate the following CrowdStrike Detects API operations:
+This sample demonstrates the following CrowdStrike Detects API operations:
 
 | Operation | Description |
 | :--- | :--- |
@@ -79,7 +100,7 @@ This sample demonstrate the following CrowdStrike Detects API operations:
 | [QueryDetects](https://falconpy.io/Service-Collections/Detects.html#querydetects) | Search for detection IDs that match a given query. |
 | [UpdateDetectsByIdsV2](https://falconpy.io/Service-Collections/Detects.html#updatedetectsbyidsv2) | Modify the state, assignee, and visibility of detections. |
 
-
+---
 
 ## Event Streams
 This category is focused on the CrowdStrike Event Streams API service collection.
@@ -90,12 +111,14 @@ This [example](https://github.com/CrowdStrike/Cloud-AWS/tree/main/Security-Hub) 
 [![Event Streams](https://img.shields.io/badge/Uber%20Class-Send%20Detections%20to%20AWS%20Security%20Hub-silver?style=for-the-badge&labelColor=maroon&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAYAAAAi2ky3AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpaIVBzuIOGSoDmJBVEQ3rUIRKoRaoVUHk5f+CE0akhQXR8G14ODPYtXBxVlXB1dBEPwBcXNzUnSREu9LCi1ifPB4H+e9c7jvXkColZhmtY0Cmm6bqURczGRXxNAruhAEMI1hmVnGrCQl4bu+7hHg512MZ/m/+3N1qzmLAQGReIYZpk28Tjy5aRuc94kjrCirxOfEIyYVSPzIdcXjN84FlwWeGTHTqTniCLFYaGGlhVnR1IgniKOqplO+kPFY5bzFWStVWKNO/sNwTl9e4jrtASSwgEVIEKGggg2UYCNGp06KhRTdx338/a5fIpdCrg0wcsyjDA2y6wefwe/eWvnxMS8pHAfaXxznYxAI7QL1quN8HztO/QQIPgNXetNfrgFTn6RXm1r0COjZBi6um5qyB1zuAH1PhmzKrsTnL+TzwPsZjSkL9N4Cnate3xr3OH0A0tSr5A1wcAgMFSh7zeffHa19+/dNo38/hq9yr+iELI0AAAAGYktHRAAAAAAAAPlDu38AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQflDAsTByz7Va2cAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAYBJREFUKM+lkjFIlVEYht/zn3sFkYYUyUnIRcemhCtCU6JQOLiIU+QeJEQg6BBIm0s4RBCBLjq5OEvgJC1uOniJhivesLx17/97/vO9b4NK4g25157hfHCGB773/cA0HZIEAKiMj+LWiOxljG/i96pnCFP58XHnrWX2+9cj0dYl9Yu2FE9/9rXrcAAgs2eSyiBfOe/XRD503h/CuffOubQVUXL+Jh9BllzBbyJJBgDclVkO4Kukd8zzkXJbeUljIldFTstsmSHM6S81ma2KfPKlFdkGAMY4wzx/bbXapMy21My+YizdKNq5mDzLkrxafSxySFKjSWX2oTmjKzz4vN0r2lOFcL/Q3V0/mX95ILMXTTGYVfaut/aP2+oCMAvnZgCcsF5fcR0dg65YHAdwB+QApADvu0AuOe/ftlJAD7Nsgmm6yBjDtfWORJZlNtFyo/lR5Z7MyheKA5ktSur7sTAHazSG27pehjAiaVfkN8b4XFIJ/wOzbOx07VNRUuHy7w98CzCcGPyWywAAAABJRU5ErkJggg==)](https://github.com/CrowdStrike/Cloud-AWS/tree/main/Security-Hub)
 
 #### Event Streams API operations discussed
-This sample demonstrate the following CrowdStrike Event Streams API operations:
+This sample demonstrates the following CrowdStrike Event Streams API operations:
 
 | Operation | Description |
 | :--- | :--- |
 | [listAvailableStreamsOAuth2](https://falconpy.io/Service-Collections/Event-Streams.html#listavailablestreamsoauth2) | Discover all event streams in your environment. |
 | [refreshActiveStreamSession](https://falconpy.io/Service-Collections/Event-Streams.html#refreshactivestreamsession) | Refresh an active event stream. Use the URL shown in a [listAvailableStreamsOAuth2](https://falconpy.io/Service-Collections/Event-Streams.html#listavailablestreamsoauth2) response. |
+
+---
 
 ## Falcon Discover
 The samples in this section focus on the CrowdStrike Falcon Discover API service collection.
@@ -106,14 +129,15 @@ In this [example](discover/list_discovered_hosts.py), we demonstrate listing up 
 
 [![Falcon Discover](https://img.shields.io/badge/Service%20Class-List%20Discovered%20Hosts-silver?style=for-the-badge&labelColor=red&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAYAAAAi2ky3AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpaIVBzuIOGSoDmJBVEQ3rUIRKoRaoVUHk5f+CE0akhQXR8G14ODPYtXBxVlXB1dBEPwBcXNzUnSREu9LCi1ifPB4H+e9c7jvXkColZhmtY0Cmm6bqURczGRXxNAruhAEMI1hmVnGrCQl4bu+7hHg512MZ/m/+3N1qzmLAQGReIYZpk28Tjy5aRuc94kjrCirxOfEIyYVSPzIdcXjN84FlwWeGTHTqTniCLFYaGGlhVnR1IgniKOqplO+kPFY5bzFWStVWKNO/sNwTl9e4jrtASSwgEVIEKGggg2UYCNGp06KhRTdx338/a5fIpdCrg0wcsyjDA2y6wefwe/eWvnxMS8pHAfaXxznYxAI7QL1quN8HztO/QQIPgNXetNfrgFTn6RXm1r0COjZBi6um5qyB1zuAH1PhmzKrsTnL+TzwPsZjSkL9N4Cnate3xr3OH0A0tSr5A1wcAgMFSh7zeffHa19+/dNo38/hq9yr+iELI0AAAAGYktHRAAAAAAAAPlDu38AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQflDAsTByz7Va2cAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAYBJREFUKM+lkjFIlVEYht/zn3sFkYYUyUnIRcemhCtCU6JQOLiIU+QeJEQg6BBIm0s4RBCBLjq5OEvgJC1uOniJhivesLx17/97/vO9b4NK4g25157hfHCGB773/cA0HZIEAKiMj+LWiOxljG/i96pnCFP58XHnrWX2+9cj0dYl9Yu2FE9/9rXrcAAgs2eSyiBfOe/XRD503h/CuffOubQVUXL+Jh9BllzBbyJJBgDclVkO4Kukd8zzkXJbeUljIldFTstsmSHM6S81ma2KfPKlFdkGAMY4wzx/bbXapMy21My+YizdKNq5mDzLkrxafSxySFKjSWX2oTmjKzz4vN0r2lOFcL/Q3V0/mX95ILMXTTGYVfaut/aP2+oCMAvnZgCcsF5fcR0dg65YHAdwB+QApADvu0AuOe/ftlJAD7Nsgmm6yBjDtfWORJZlNtFyo/lR5Z7MyheKA5ktSur7sTAHazSG27pehjAiaVfkN8b4XFIJ/wOzbOx07VNRUuHy7w98CzCcGPyWywAAAABJRU5ErkJggg==)](discover/list_discovered_hosts.py) 
 
-#### Cloud Connect AWS API operations discussed
-This sample demonstrate the following CrowdStrike Discover API operations:
+#### Discover API operations discussed
+This sample demonstrates the following CrowdStrike Discover API operations:
 
 | Operation | Description |
 | :--- | :--- |
 | [get_hosts](https://falconpy.io/Service-Collections/Discover.html#get_hosts) | Get details on assets by providing one or more IDs. |
 | [query_hosts](https://falconpy.io/Service-Collections/Discover.html#query_hosts) | Search for assets in your environment by providing a FQL (Falcon Query Language) filter and paging details. Returns a set of asset IDs which match the filter criteria. |
 
+---
 
 ## Falcon Discover for Cloud and Containers (AWS Accounts)
 This section discusses Falcon Discover for Cloud and Containers, and the two API service collections, Cloud Connect AWS and D4C Registration.
@@ -135,6 +159,8 @@ These samples demonstrate the following CrowdStrike Cloud Connect AWS (Discover 
 | [UpdateAWSAccounts](https://falconpy.io/Service-Collections/Cloud-Connect-AWS.html#updateawsaccounts) | Update AWS Accounts by specifying the ID of the account and details to update. |
 | [VerifyAWSAccountAccess](https://falconpy.io/Service-Collections/Cloud-Connect-AWS.html#verifyawsaccountaccess) | Search for provisioned AWS Accounts by providing a FQL filter and paging details. Returns a set of AWS account IDs which match the filter criteria. |
 
+---
+
 ## Falcon Horizon
 These samples focus on CrowdStrike Falcon Horizon and the available API operations within the CSPM Registration service collection.
 
@@ -144,12 +170,13 @@ Submitted by `@mccbryan3`, this [example](cspm_registration/get_cspm_policies.py
 [![Falcon Horizon](https://img.shields.io/badge/Service%20Class-Report%20Horizon%20Policies-silver?style=for-the-badge&labelColor=red&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAYAAAAi2ky3AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpaIVBzuIOGSoDmJBVEQ3rUIRKoRaoVUHk5f+CE0akhQXR8G14ODPYtXBxVlXB1dBEPwBcXNzUnSREu9LCi1ifPB4H+e9c7jvXkColZhmtY0Cmm6bqURczGRXxNAruhAEMI1hmVnGrCQl4bu+7hHg512MZ/m/+3N1qzmLAQGReIYZpk28Tjy5aRuc94kjrCirxOfEIyYVSPzIdcXjN84FlwWeGTHTqTniCLFYaGGlhVnR1IgniKOqplO+kPFY5bzFWStVWKNO/sNwTl9e4jrtASSwgEVIEKGggg2UYCNGp06KhRTdx338/a5fIpdCrg0wcsyjDA2y6wefwe/eWvnxMS8pHAfaXxznYxAI7QL1quN8HztO/QQIPgNXetNfrgFTn6RXm1r0COjZBi6um5qyB1zuAH1PhmzKrsTnL+TzwPsZjSkL9N4Cnate3xr3OH0A0tSr5A1wcAgMFSh7zeffHa19+/dNo38/hq9yr+iELI0AAAAGYktHRAAAAAAAAPlDu38AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQflDAsTByz7Va2cAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAYBJREFUKM+lkjFIlVEYht/zn3sFkYYUyUnIRcemhCtCU6JQOLiIU+QeJEQg6BBIm0s4RBCBLjq5OEvgJC1uOniJhivesLx17/97/vO9b4NK4g25157hfHCGB773/cA0HZIEAKiMj+LWiOxljG/i96pnCFP58XHnrWX2+9cj0dYl9Yu2FE9/9rXrcAAgs2eSyiBfOe/XRD503h/CuffOubQVUXL+Jh9BllzBbyJJBgDclVkO4Kukd8zzkXJbeUljIldFTstsmSHM6S81ma2KfPKlFdkGAMY4wzx/bbXapMy21My+YizdKNq5mDzLkrxafSxySFKjSWX2oTmjKzz4vN0r2lOFcL/Q3V0/mX95ILMXTTGYVfaut/aP2+oCMAvnZgCcsF5fcR0dg65YHAdwB+QApADvu0AuOe/ftlJAD7Nsgmm6yBjDtfWORJZlNtFyo/lR5Z7MyheKA5ktSur7sTAHazSG27pehjAiaVfkN8b4XFIJ/wOzbOx07VNRUuHy7w98CzCcGPyWywAAAABJRU5ErkJggg==)](cspm_registration/get_cspm_policies.py) 
 
 #### CSPM Registration API operations discussed
-This sample demonstrate the following CrowdStrike CSPM Registration (Horizon) API operations:
+This sample demonstrates the following CrowdStrike CSPM Registration (Horizon) API operations:
 
 | Operation | Description |
 | :--- | :--- |
 | [GetCSPMPolicySettings](https://falconpy.io/Service-Collections/CSPM-Registration.html#getcspmpolicysettings) | Returns information about current policy settings. |
 
+---
 
 ## Falcon Flight Control
 The samples in this category demonstrate functionality for MSSP scenarios using the Falcon Flight Control API service collection.
@@ -160,11 +187,13 @@ This [example](flight_control/find_child_cid.py) demonstrates retrieving a child
 [![Falcon Flight Control](https://img.shields.io/badge/Service%20Class-Find%20Child%20CID-silver?style=for-the-badge&labelColor=red&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAYAAAAi2ky3AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpaIVBzuIOGSoDmJBVEQ3rUIRKoRaoVUHk5f+CE0akhQXR8G14ODPYtXBxVlXB1dBEPwBcXNzUnSREu9LCi1ifPB4H+e9c7jvXkColZhmtY0Cmm6bqURczGRXxNAruhAEMI1hmVnGrCQl4bu+7hHg512MZ/m/+3N1qzmLAQGReIYZpk28Tjy5aRuc94kjrCirxOfEIyYVSPzIdcXjN84FlwWeGTHTqTniCLFYaGGlhVnR1IgniKOqplO+kPFY5bzFWStVWKNO/sNwTl9e4jrtASSwgEVIEKGggg2UYCNGp06KhRTdx338/a5fIpdCrg0wcsyjDA2y6wefwe/eWvnxMS8pHAfaXxznYxAI7QL1quN8HztO/QQIPgNXetNfrgFTn6RXm1r0COjZBi6um5qyB1zuAH1PhmzKrsTnL+TzwPsZjSkL9N4Cnate3xr3OH0A0tSr5A1wcAgMFSh7zeffHa19+/dNo38/hq9yr+iELI0AAAAGYktHRAAAAAAAAPlDu38AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQflDAsTByz7Va2cAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAYBJREFUKM+lkjFIlVEYht/zn3sFkYYUyUnIRcemhCtCU6JQOLiIU+QeJEQg6BBIm0s4RBCBLjq5OEvgJC1uOniJhivesLx17/97/vO9b4NK4g25157hfHCGB773/cA0HZIEAKiMj+LWiOxljG/i96pnCFP58XHnrWX2+9cj0dYl9Yu2FE9/9rXrcAAgs2eSyiBfOe/XRD503h/CuffOubQVUXL+Jh9BllzBbyJJBgDclVkO4Kukd8zzkXJbeUljIldFTstsmSHM6S81ma2KfPKlFdkGAMY4wzx/bbXapMy21My+YizdKNq5mDzLkrxafSxySFKjSWX2oTmjKzz4vN0r2lOFcL/Q3V0/mX95ILMXTTGYVfaut/aP2+oCMAvnZgCcsF5fcR0dg65YHAdwB+QApADvu0AuOe/ftlJAD7Nsgmm6yBjDtfWORJZlNtFyo/lR5Z7MyheKA5ktSur7sTAHazSG27pehjAiaVfkN8b4XFIJ/wOzbOx07VNRUuHy7w98CzCcGPyWywAAAABJRU5ErkJggg==)](flight_control/find_child_cid.py) [![MSSP Use supported](https://img.shields.io/badge/-Supports%20MSSP-darkblue?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAYAAAAi2ky3AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpaIVBzuIOGSoDmJBVEQ3rUIRKoRaoVUHk5f+CE0akhQXR8G14ODPYtXBxVlXB1dBEPwBcXNzUnSREu9LCi1ifPB4H+e9c7jvXkColZhmtY0Cmm6bqURczGRXxNAruhAEMI1hmVnGrCQl4bu+7hHg512MZ/m/+3N1qzmLAQGReIYZpk28Tjy5aRuc94kjrCirxOfEIyYVSPzIdcXjN84FlwWeGTHTqTniCLFYaGGlhVnR1IgniKOqplO+kPFY5bzFWStVWKNO/sNwTl9e4jrtASSwgEVIEKGggg2UYCNGp06KhRTdx338/a5fIpdCrg0wcsyjDA2y6wefwe/eWvnxMS8pHAfaXxznYxAI7QL1quN8HztO/QQIPgNXetNfrgFTn6RXm1r0COjZBi6um5qyB1zuAH1PhmzKrsTnL+TzwPsZjSkL9N4Cnate3xr3OH0A0tSr5A1wcAgMFSh7zeffHa19+/dNo38/hq9yr+iELI0AAAAGYktHRAAAAAAAAPlDu38AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQflDAsTByz7Va2cAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAYBJREFUKM+lkjFIlVEYht/zn3sFkYYUyUnIRcemhCtCU6JQOLiIU+QeJEQg6BBIm0s4RBCBLjq5OEvgJC1uOniJhivesLx17/97/vO9b4NK4g25157hfHCGB773/cA0HZIEAKiMj+LWiOxljG/i96pnCFP58XHnrWX2+9cj0dYl9Yu2FE9/9rXrcAAgs2eSyiBfOe/XRD503h/CuffOubQVUXL+Jh9BllzBbyJJBgDclVkO4Kukd8zzkXJbeUljIldFTstsmSHM6S81ma2KfPKlFdkGAMY4wzx/bbXapMy21My+YizdKNq5mDzLkrxafSxySFKjSWX2oTmjKzz4vN0r2lOFcL/Q3V0/mX95ILMXTTGYVfaut/aP2+oCMAvnZgCcsF5fcR0dg65YHAdwB+QApADvu0AuOe/ftlJAD7Nsgmm6yBjDtfWORJZlNtFyo/lR5Z7MyheKA5ktSur7sTAHazSG27pehjAiaVfkN8b4XFIJ/wOzbOx07VNRUuHy7w98CzCcGPyWywAAAABJRU5ErkJggg==&style=for-the-badge)](flight_control/find_child_cid.py)
 
 #### Flight Control API operations discussed
-This sample demonstrate the following CrowdStrike Flight Control API operations:
+This sample demonstrates the following CrowdStrike Flight Control API operations:
 
 | Operation | Description |
 | :--- | :--- |
 | [QueryChildren](https://falconpy.io/Service-Collections/MSSP.html#querychildren) | Query for customers linked as children. |
+
+---
 
 ## Falcon X
 This category is dedicated to Falcon X, and discusses the Falcon X Sandbox, Quick Scan, and Sample Uploads API service collections.
@@ -264,6 +293,8 @@ This sample demonstrates the following CrowdStrike Quick Scan and Sample Uploads
 | [ScanSamples](https://falconpy.io/Service-Collections/Quick-Scan.html#scansamples) | Submit a volume of files for ml scanning. Time required for analysis increases with the number of samples in a volume but usually it should take less than 1 minute. |
 | [UploadSampleV3](https://falconpy.io/Service-Collections/Sample-Uploads.html#uploadsamplev3) | Upload a file for further cloud analysis. After uploading, call the specific analysis API endpoint. |
 
+---
+
 ## Firewall Management
 The CrowdStrike Falcon Firewall Management and Firewall Policies APIs are the focus of this section.
 
@@ -273,13 +304,14 @@ Developed by `@wozboz`, this [example](firewall_management/get_firewall_events.p
 [![Firewall Management](https://img.shields.io/badge/Service%20Class-Export_Firewall_Events-silver?style=for-the-badge&labelColor=red&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAYAAAAi2ky3AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpaIVBzuIOGSoDmJBVEQ3rUIRKoRaoVUHk5f+CE0akhQXR8G14ODPYtXBxVlXB1dBEPwBcXNzUnSREu9LCi1ifPB4H+e9c7jvXkColZhmtY0Cmm6bqURczGRXxNAruhAEMI1hmVnGrCQl4bu+7hHg512MZ/m/+3N1qzmLAQGReIYZpk28Tjy5aRuc94kjrCirxOfEIyYVSPzIdcXjN84FlwWeGTHTqTniCLFYaGGlhVnR1IgniKOqplO+kPFY5bzFWStVWKNO/sNwTl9e4jrtASSwgEVIEKGggg2UYCNGp06KhRTdx338/a5fIpdCrg0wcsyjDA2y6wefwe/eWvnxMS8pHAfaXxznYxAI7QL1quN8HztO/QQIPgNXetNfrgFTn6RXm1r0COjZBi6um5qyB1zuAH1PhmzKrsTnL+TzwPsZjSkL9N4Cnate3xr3OH0A0tSr5A1wcAgMFSh7zeffHa19+/dNo38/hq9yr+iELI0AAAAGYktHRAAAAAAAAPlDu38AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQflDAsTByz7Va2cAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAYBJREFUKM+lkjFIlVEYht/zn3sFkYYUyUnIRcemhCtCU6JQOLiIU+QeJEQg6BBIm0s4RBCBLjq5OEvgJC1uOniJhivesLx17/97/vO9b4NK4g25157hfHCGB773/cA0HZIEAKiMj+LWiOxljG/i96pnCFP58XHnrWX2+9cj0dYl9Yu2FE9/9rXrcAAgs2eSyiBfOe/XRD503h/CuffOubQVUXL+Jh9BllzBbyJJBgDclVkO4Kukd8zzkXJbeUljIldFTstsmSHM6S81ma2KfPKlFdkGAMY4wzx/bbXapMy21My+YizdKNq5mDzLkrxafSxySFKjSWX2oTmjKzz4vN0r2lOFcL/Q3V0/mX95ILMXTTGYVfaut/aP2+oCMAvnZgCcsF5fcR0dg65YHAdwB+QApADvu0AuOe/ftlJAD7Nsgmm6yBjDtfWORJZlNtFyo/lR5Z7MyheKA5ktSur7sTAHazSG27pehjAiaVfkN8b4XFIJ/wOzbOx07VNRUuHy7w98CzCcGPyWywAAAABJRU5ErkJggg==)](firewall_management/get_firewall_events.py)
 
 #### Firewall Management operations discussed
-This sample demonstrate the following CrowdStrike Firewall Management API operations:
+This sample demonstrates the following CrowdStrike Firewall Management API operations:
 
 | Operation | Description |
 | :--- | :--- |
 | [get_events](https://falconpy.io/Service-Collections/Firewall-Management.html#get_events) | Get events entities by ID and optionally version. |
 | [query_events](https://falconpy.io/Service-Collections/Firewall-Management.html#query_events) | Find all event IDs matching the query with filter. |
 
+---
 
 ## Hosts
 The samples collected in this section demonstrate leveraging CrowdStrike's Hosts and Host Group API service collections to secure your endpoints.
@@ -336,6 +368,7 @@ This sample demonstrates the following CrowdStrike Hosts API operations:
 | [QueryDevicesByFilter](https://falconpy.io/Service-Collections/Hosts.html#querydevicesbyfilter) | Search for hosts in your environment by platform, hostname, IP, and other criteria. |
 | [QueryDeviceLoginHistory](https://www.falconpy.io/Service-Collections/Hosts.html#querydeviceloginhistory) | Retrieve details about recent login sessions for a set of devices. |
 | [UpdateDeviceTags](https://www.falconpy.io/Service-Collections/Hosts.html#updatedevicetags) | Append or remove one or more Falcon Grouping Tags on one or more hosts. |
+
 ---
 
 ### Offset vs. Token
@@ -381,6 +414,8 @@ This sample demonstrates the following CrowdStrike Hosts API operations:
 | [PerformActionV2](https://falconpy.io/Service-Collections/Hosts.html#performactionv2) | Take various actions on the hosts in your environment. Contain or lift containment on a host. Delete or restore a host. |
 | [QueryDevicesByFilter](https://falconpy.io/Service-Collections/Hosts.html#querydevicesbyfilter) | Search for hosts in your environment by platform, hostname, IP, and other criteria. |
 
+---
+
 ## Incidents
 This category is dedicated to demonstrating the functionality provided by the CrowdStrike Incidents API service collection.
 
@@ -399,6 +434,8 @@ This sample demonstrates the following CrowdStrike Incidents API operations:
 | :--- | :--- |
 | [CrowdScore](https://falconpy.io/Service-Collections/Incidents.html#crowdscore) | Query environment wide CrowdScore and return the entity data. |
 
+---
+
 ### Incident Triage
 This example demonstrates triaging Incidents. You can assign / unassign responders, add / remove tags, and change name, description and status of an incident using the [Incident Triage](incidents#incident-triage) utility.
 
@@ -412,6 +449,8 @@ This sample demonstrates the following CrowdStrike Incidents API operations:
 | [PerformIncidentAction](https://falconpy.io/Service-Collections/Incidents.html#performincidentaction) | Perform a set of actions on one or more incidents, such as adding tags or comments or updating the incident name or description. |
 | [GetIncidents](https://falconpy.io/Service-Collections/Incidents.html#getincidents) | Get details on incidents by providing incident IDs. |
 | [QueryIncidents](https://falconpy.io/Service-Collections/Incidents.html#queryincidents) | Search for incidents by providing a FQL filter, sorting, and paging details. |
+
+---
 
 ## Intel
 This category provides samples that demonstrate the CrowdStrike Falcon Intel API service collection.
@@ -433,7 +472,7 @@ This sample demonstrates the following CrowdStrike Intel API operations:
 | [QueryIntelIndicatorEntities](https://falconpy.io/Service-Collections/Intel.html#queryintelindicatorentities) | Get info about indicators that match provided FQL filters. |
 | [QueryIntelReportEntities](https://falconpy.io/Service-Collections/Intel.html#queryintelreportentities) | Get info about reports that match provided FQL filters. |
 
-
+---
 
 ## IOC
 The samples in this section focus on the CrowdStrike IOC API service collection.
@@ -451,6 +490,7 @@ This sample demonstrates the following CrowdStrike IOC API operations:
 | :--- | :--- |
 | [indicator_create_v1](https://falconpy.io/Service-Collections/IOC.html#indicator_create_v1) | Create indicators. |
 
+---
 
 ## MalQuery
 This section is dedicated to the CrowdStrike MalQuery API service collection.
@@ -472,6 +512,8 @@ This sample demonstrates the following CrowdStrike MalQuery API operations:
 | [PostMalQueryEntitiesSamplesMultidownloadV1](https://falconpy.io/Service-Collections/MalQuery.html#postmalqueryentitiessamplesmultidownloadv1) | Schedule samples for download. Use the result id with the /request endpoint to check if the download is ready after which you can call the /entities/samples-fetch to get the zip. |
 | [PostMalQueryFuzzySearchV1](https://falconpy.io/Service-Collections/MalQuery.html#postmalqueryfuzzysearchv1) | Search Falcon MalQuery quickly, but with more potential for false positives. Search for a combination of hex patterns and strings in order to identify samples based upon file content at byte level granularity. |
 
+---
+
 ## Prevention Policy
 The samples in this section demonstrate using CrowdStrike's Prevention Policy API service collection.
 
@@ -492,7 +534,7 @@ This sample demonstrates the following CrowdStrike Prevention Policy API operati
 | [queryPreventionPolicies](https://falconpy.io/Service-Collections/Prevention-Policy.html#querypreventionpolicies) | Search for Prevention Policies in your environment by providing a FQL filter and paging details. Returns a set of Prevention Policy IDs which match the filter criteria. |
 | [updatePreventionPolicies](https://falconpy.io/Service-Collections/Prevention-Policy.html#updatepreventionpolicies) | Update Prevention Policies by specifying the ID of the policy and details to update. |
 
-
+---
 
 ## Real Time Response
 These samples focus on CrowdStrike's Real Time Response and Real Time Response Admin API service collections.
@@ -616,6 +658,8 @@ This sample demonstrates the following CrowdStrike Sensor Download API operation
 | [DownloadSensorInstallerById](https://falconpy.io/Service-Collections/Sensor-Download.html#downloadsensorinstallerbyid) | Get sensor installer details by providing a query. |
 | [GetCombinedSensorInstallersByQuery](https://falconpy.io/Service-Collections/Sensor-Download.html#getcombinedsensorinstallersbyquery) | Download sensor installer by SHA256 ID. |
 
+---
+
 ## Sensor Update Policies
 This section has samples that focus on the CrowdStrike Sensor Update Policies API service collection.
 
@@ -640,6 +684,7 @@ This sample demonstrates the following CrowdStrike Sensor Update Policies API op
 | [setSensorUpdatePoliciesPrecedence](https://falconpy.io/Service-Collections/Sensor-Update-Policy.html#setsensorupdatepoliciesprecedence) | Sets the precedence of Sensor Update Policies based on the order of IDs specified in the request. The first ID specified will have the highest precedence and the last ID specified will have the lowest. You must specify all non-Default Policies for a platform when updating precedence. |
 | [updateSensorUpdatePoliciesV2](https://falconpy.io/Service-Collections/Sensor-Update-Policy.html#updatesensorupdatepolicies) | Update Sensor Update Policies by specifying the ID of the policy and details to update with additional support for uninstall protection. |
 
+---
 
 ## Spotlight
 These samples discuss leveraging the CrowdStrike Spotlight Evaluation Logic and Spotlight Vulnerabilities API service collections.
@@ -675,6 +720,8 @@ This sample demonstrates the following CrowdStrike Spotlight Vulnerability API o
 | :--- | :--- |
 | [queryVulnerabilities](https://falconpy.io/Service-Collections/Spotlight-Vulnerabilities.html#queryvulnerabilities) | Search for Vulnerabilities in your environment by providing a FQL filter and paging details. Returns a set of Vulnerability IDs which match the filter criteria. |
 
+---
+
 ## User Management
 This sample category is focused on examples that leverage CrowdStrike's User Management API service collection.
 
@@ -698,7 +745,7 @@ This sample demonstrates the following CrowdStrike User Management API operation
 | [RetrieveUserUUIDsByCID](https://falconpy.io/Service-Collections/User-Management.html#retrieveuseruuidsbycid) | List user IDs for all users in your customer account. For more information on each user, provide the user ID to [RetrieveUser](https://falconpy.io/Service-Collections/User-Management.html#retrieveuser). |
 | [RevokeUserRoleIds](https://falconpy.io/Service-Collections/User-Management.html#revokeuserroleids) | Revoke one or more roles from a user. |
 
-
+---
 
 
 ## Suggestions

--- a/samples/cspm_registration/get_cspm_policies.py
+++ b/samples/cspm_registration/get_cspm_policies.py
@@ -126,10 +126,13 @@ def chunk_long_description(desc, col_width) -> str:
 policies = falcon.get_policy_settings(cloud_platform=cloud)['body']['resources']
 # Call format function on the returned api data
 return_data = format_json_data(policies)
-
 # Determine if an output file is specified and write out or print
 if data_file:
-    keys = return_data[0].keys()
+    keys = []
+    for row in return_data:
+        for key in row.keys():
+            if key not in keys:
+                keys.append(key)
     with open(data_file, 'w', newline='', encoding="utf-8") as output_file:
         dict_writer = csv.DictWriter(output_file, keys)
         dict_writer.writeheader()

--- a/samples/custom_ioa/README.md
+++ b/samples/custom_ioa/README.md
@@ -1,0 +1,166 @@
+![CrowdStrike Falcon](https://raw.githubusercontent.com/CrowdStrike/falconpy/main/docs/asset/cs-logo.png)
+
+![Twitter URL](https://img.shields.io/twitter/url?label=Follow%20%40CrowdStrike&style=social&url=https%3A%2F%2Ftwitter.com%2FCrowdStrike)
+
+# Custom IOA examples
+The examples in this folder focus on leveraging CrowdStrike's Custom IOA API to manage Indicators of Attack within your Falcon Tenant.
+
+- [Custom IOA Cloner](#custom-ioa-cloner) - Clone, delete and display Custom IOA rule groups.
+
+## Custom IOA Cloner
+
++ [Running the program](#running-the-program)
++ [Execution syntax](#execution-syntax)
++ [Example source code](#example-source-code)
+
+### Running the program
+In order to run this demonstration, you will need access to CrowdStrike API keys with the following scopes:
+| Service Collection | Scope |
+| :---- | :---- |
+| Custom IOA | __READ__, __WRITE__ |
+
+
+### Execution syntax
+This demonstration was developed to leverage easy to use command-line arguments.
+
+- [Command line arguments](#command-line-arguments)
+- [Basic usage](#basic-usage)
+- [Filtering by name](#filtering-by-name)
+- [Cloning IOA rule groups](#cloning-ioa-rule-groups)
+- [Deleting IOA rule groups](#deleting-ioa-rule-groups)
+- [Command-line help](#command-line-help)
+
+
+#### Command line arguments
+This program accepts the following command line arguments.
+
+| Argument | Long Argument | Description |
+| :-- | :-- | :-- |
+| `-h` | `--help` | Display command line help and exit |
+| `-n` | `--no_color` | Disable color output in result displays |
+| `-b` | `--base_url` | Base URL |
+| `-t` _TABLE_FORMAT_ | `--table_format` _TABLE_FORMAT_ | Table format to use for display, one of: <BR/>`plain`, `simple`, `github`, `grid`, `fancy_grid`, `pipe`, `orgtbl`, `jira`, `presto`, `pretty`, `psql`, `rst`, `mediawiki`, `moinmoin`, `youtrack`, `html`, `unsafehtml`, `latext`, `latex_raw`, `latex_booktabs`, `latex_longtable`, `textile`, or `tsv`. |
+| `-f` _FILTER_ | `--filter` _FILTER_ | String to filter results (IOA rule group name) |
+| `-c` | `--clone` | Clone all IOA rule group matches to new rule groups |
+| `-d` DELETE | `--delete` DELETE | List of rule group IDs to delete (comma-delimit) |
+| `-k` _FALCON_CLIENT_ID_ | `--falcon_client_id` _FALCON_CLIENT_ID_ | CrowdStrike Falcon API Client ID |
+| `-s` _FALCON_CLIENT_SECRET_ | `--falcon_client_secret` _FALCON_CLIENT_SECRET_ | CrowdStrike Falcon API Client Secret |
+
+#### Basic usage
+The only required command line arguments are `-k` (CrowdStrike Falcon API Client ID) and `-s` (CrowdStrike Falcon API Client Secret).
+
+The default command is "list" with no filters specified, which displays all Custom IOA rule groups within your tenant.
+
+##### Example
+
+```shell
+python3 custom_ioa_clone.py -k CLIENT_ID_HERE -s CLIENT_SECRET_HERE
+```
+
+##### Example result
+
+```shell
+_______ _     _ _______ _______  _____  _______      _____  _____  _______
+|       |     | |______    |    |     | |  |  |        |   |     | |_____|
+|_____  |_____| ______|    |    |_____| |  |  |      __|__ |_____| |     |
+
+╒══════════════════════════════════╤══════════════════════════════════════════╤════════════╤═════════════════════════════════╕
+│ Custom IOA Name                  │ Description                              │ Platform   │ Rules                           │
+╞══════════════════════════════════╪══════════════════════════════════════════╪════════════╪═════════════════════════════════╡
+│ Windows Test IOA                 │ Test IOA for windows                     │ windows    │ windows custom IOA (ver: 2)     │
+│ abc1d2ef3g456ab7cd89e0fa1b23cd4e │                                          │ Enabled    │                                 │
+│                                  │                                          │ Version: 1 │                                 │
+├──────────────────────────────────┼──────────────────────────────────────────┼────────────┼─────────────────────────────────┤
+│ Linux Test IOA                   │ Validation test policy for custom IOA to │ linux      │                                 │
+│ 1bc1f2ec3a426ab7cd89e0fa1b23cd4f │ test linux                               │ Disabled   │                                 │
+│                                  │                                          │ Version: 1 │                                 │
+├──────────────────────────────────┼──────────────────────────────────────────┼────────────┼─────────────────────────────────┤
+│ test IOA                         │ test IOA                                 │ windows    │                                 │
+│ abc1d2ef3g4c4cba4d89e02a1b23cd4a │                                          │ Disabled   │                                 │
+│                                  │                                          │ Version: 1 │                                 │
+├──────────────────────────────────┼──────────────────────────────────────────┼────────────┼─────────────────────────────────┤
+│ Exploit Demo                     │ Exploit Demo                             │ linux      │ SecFrameWork (ver: 4)           │
+│ 6bc1d2ef3g456ab83d8ae0ba1b23cd4b │                                          │ Disabled   │                                 │
+│                                  │                                          │ Version: 1 │                                 │
+├──────────────────────────────────┼──────────────────────────────────────────┼────────────┼─────────────────────────────────┤
+│ Sec Framework IOA's              │ Security Framework Custom IOAs           │ linux      │ SecFrameWork (ver: 20)          │
+│ abc1d2ef3a453ab1cd89e0f41b23cd4c │                                          │ Enabled    │ Detect Shell Shoveling (ver: 4) │
+│                                  │                                          │ Version: 1 │                                 │
+╘══════════════════════════════════╧══════════════════════════════════════════╧════════════╧═════════════════════════════════╛
+```
+
+#### Filtering by name
+You can filter results down using the `-f` argument to filter by name.
+```shell
+python3 custom_ioa_clone.py -k CLIENT_ID_HERE -s CLIENT_SECRET_HERE -f SEARCH_STRING
+```
+
+#### Cloning IOA rule groups
+Cloning IOA rule groups can be performed by passing the `-c` argument. Any matches to the filter string (`-f`) are cloned.
+
+```shell
+python3 custom_ioa_clone.py -k CLIENT_ID_HERE -s CLIENT_SECRET_HERE -f SEARCH_STRING -c
+```
+
+#### Deleting IOA rule groups
+You must provide the exact rule group ID in order to delete using the `-d` argument. Multiple IDs may be specified at the
+same time if you provide these as a comma-delimited list.
+
+```shell
+python3 custom_ioa_clone.py -k CLIENT_ID_HERE -s CLIENT_SECRET_HERE -d RULE_GROUP_ID1,RULE_GROUP_ID2
+```
+
+#### Command-line help
+Command-line help is available via the `-h` argument.
+
+```shell
+usage: custom_ioa_clone.py [-h] [-n] [-b BASE_URL] [-t TABLE_FORMAT] [-f FILTER] [-c] [-d DELETE] [-k FALCON_CLIENT_ID] [-s FALCON_CLIENT_SECRET]
+
+Custom IOA duplicator.
+
+ ______                         __ _______ __         __ __
+|      |.----.-----.--.--.--.--|  |     __|  |_.----.|__|  |--.-----.
+|   ---||   _|  _  |  |  |  |  _  |__     |   _|   _||  |    <|  -__|
+|______||__| |_____|________|_____|_______|____|__|  |__|__|__|_____|
+
+ ____                     __                           ______   _____   ______
+/\  _`\                  /\ \__                       /\__  _\ /\  __`\/\  _  \
+\ \ \/\_\  __  __    ____\ \ ,_\   ___     ___ ___    \/_/\ \/ \ \ \/\ \ \ \L\ \
+ \ \ \/_/_/\ \/\ \  /',__\\ \ \/  / __`\ /' __` __`\     \ \ \  \ \ \ \ \ \  __ \
+  \ \ \L\ \ \ \_\ \/\__, `\\ \ \_/\ \L\ \/\ \/\ \/\ \     \_\ \__\ \ \_\ \ \ \/\ \
+   \ \____/\ \____/\/\____/ \ \__\ \____/\ \_\ \_\ \_\    /\_____\\ \_____\ \_\ \_\
+    \/___/  \/___/  \/___/   \/__/\/___/  \/_/\/_/\/_/    \/_____/ \/_____/\/_/\/_/
+
+                                                 ______ __
+                                                |      |  |.-----.-----.-----.----.
+                                                |   ---|  ||  _  |     |  -__|   _|
+                                                |______|__||_____|__|__|_____|__|
+
+                                                 CrowdStrike FalconPy v.1.1
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -n, --nocolor         Disable color output
+  -b BASE_URL, --base_url BASE_URL
+                        Base URL
+  -t TABLE_FORMAT, --table_format TABLE_FORMAT
+                        Tabular display format
+
+search arguments:
+  -f FILTER, --filter FILTER
+                        String to filter results (IOA rule group name)
+
+action arguments:
+  -c, --clone           Clone all IOA rule group matches to new rule groups
+  -d DELETE, --delete DELETE
+                        List of rule group IDs to delete (comma-delimit)
+
+required arguments:
+  -k FALCON_CLIENT_ID, --falcon_client_id FALCON_CLIENT_ID
+                        CrowdStrike Falcon API Client ID
+  -s FALCON_CLIENT_SECRET, --falcon_client_secret FALCON_CLIENT_SECRET
+                        CrowdStrike Falcon API Client Secret
+```
+
+### Example source code
+Source code for this example can be found [here](custom_ioa_clone.py).

--- a/samples/custom_ioa/custom_ioa_clone.py
+++ b/samples/custom_ioa/custom_ioa_clone.py
@@ -1,0 +1,249 @@
+r"""Custom IOA duplicator.
+
+ ______                         __ _______ __         __ __
+|      |.----.-----.--.--.--.--|  |     __|  |_.----.|__|  |--.-----.
+|   ---||   _|  _  |  |  |  |  _  |__     |   _|   _||  |    <|  -__|
+|______||__| |_____|________|_____|_______|____|__|  |__|__|__|_____|
+
+ ____                     __                           ______   _____   ______
+/\  _`\                  /\ \__                       /\__  _\ /\  __`\/\  _  \
+\ \ \/\_\  __  __    ____\ \ ,_\   ___     ___ ___    \/_/\ \/ \ \ \/\ \ \ \L\ \
+ \ \ \/_/_/\ \/\ \  /',__\\ \ \/  / __`\ /' __` __`\     \ \ \  \ \ \ \ \ \  __ \
+  \ \ \L\ \ \ \_\ \/\__, `\\ \ \_/\ \L\ \/\ \/\ \/\ \     \_\ \__\ \ \_\ \ \ \/\ \
+   \ \____/\ \____/\/\____/ \ \__\ \____/\ \_\ \_\ \_\    /\_____\\ \_____\ \_\ \_\
+    \/___/  \/___/  \/___/   \/__/\/___/  \/_/\/_/\/_/    \/_____/ \/_____/\/_/\/_/
+
+                                                 ______ __
+                                                |      |  |.-----.-----.-----.----.
+                                                |   ---|  ||  _  |     |  -__|   _|
+                                                |______|__||_____|__|__|_____|__|
+
+                                                 CrowdStrike FalconPy v.1.1
+"""
+from argparse import ArgumentParser, RawTextHelpFormatter
+from falconpy import CustomIOA
+from tabulate import tabulate
+
+
+class Color:  # pylint: disable=R0903
+    """Class to represent the text color codes used for terminal output."""
+
+    PURPLE = "\033[95m"
+    CYAN = "\033[96m"
+    DARKCYAN = "\033[36m"
+    MAGENTA = "\033[35m"
+    BLUE = "\033[34m"
+    LIGHTBLUE = "\033[94m"
+    GREEN = "\033[32m"
+    LIGHTGREEN = "\033[92m"
+    LIGHTYELLOW = "\033[93m"
+    YELLOW = "\033[33m"
+    RED = "\033[31m"
+    LIGHTRED = "\033[91m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+    END = "\033[0m"
+
+
+def consume_arguments():
+    """Consume any user provided arguments."""
+    parser = ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
+    parser.add_argument("-n", "--nocolor",
+                        help="Disable color output",
+                        required=False,
+                        action="store_true",
+                        default=False
+                        )
+    parser.add_argument("-b", "--base_url",
+                        help="Base URL",
+                        required=False,
+                        default="auto"
+                        )
+    parser.add_argument("-t", "--table_format",
+                        help="Tabular display format",
+                        required=False,
+                        default="fancy_grid"
+                        )
+    srch = parser.add_argument_group("search arguments")
+    srch.add_argument("-f", "--filter",
+                      help="String to filter results (IOA rule group name)",
+                      required=False,
+                      default=None
+                      )
+    act = parser.add_argument_group("action arguments")
+    act.add_argument("-c", "--clone",
+                     help="Clone all IOA rule group matches to new rule groups",
+                     required=False,
+                     action="store_true",
+                     default=False
+                     )
+    act.add_argument("-d", "--delete",
+                     help="List of rule group IDs to delete (comma-delimit)",
+                     required=False,
+                     default=None
+                     )
+    req = parser.add_argument_group("required arguments")
+    req.add_argument("-k", "--falcon_client_id",
+                     help="CrowdStrike Falcon API Client ID",
+                     required=False
+                     )
+    req.add_argument("-s", "--falcon_client_secret",
+                     help="CrowdStrike Falcon API Client Secret",
+                     required=False
+                     )
+
+    return parser.parse_args()
+
+
+def open_sdk(client_id: str, client_secret: str, base: str):
+    """Create instances of our the Custom IOA Service Class and return it."""
+    return CustomIOA(client_id=client_id, client_secret=client_secret, base_url=base)
+
+
+def chunk_long_description(desc, col_width) -> str:
+    """Chunks a long string by delimiting with CR based upon column length."""
+    desc_chunks = []
+    chunk = ""
+    for word in desc.split():
+        new_chunk = f"{chunk} {word.strip()}"
+        if len(new_chunk) >= col_width:
+            if new_chunk[0] == " ":
+                new_chunk = new_chunk[1:]
+            desc_chunks.append(new_chunk)
+            chunk = ""
+        else:
+            chunk = new_chunk
+
+    delim = "\n"
+    desc_chunks.append(chunk[1:])
+
+    return delim.join(desc_chunks)
+
+
+def get_ioa_list(sdk: CustomIOA, filter_string: str = None):
+    """Return the list of IOAs based upon the provided filter."""
+    parameters = {}
+    if filter_string:
+        parameters["filter"] = f"name:*'*{filter_string}*'"
+    return sdk.query_rule_groups_full(parameters=parameters)
+
+
+def show_ioas(matches: dict, table_format: str):
+    """Display the IOA listing in tabular format."""
+    banner = [
+        f"{Color.MAGENTA}",
+        "_______ _     _ _______ _______  _____  _______      _____  _____  _______",
+        "|       |     | |______    |    |     | |  |  |        |   |     | |_____|",
+        f"|_____  |_____| ______|    |    |_____| |  |  |      __|__ |_____| |     |{Color.END}\n"
+        ]
+    headers = {
+        "name": f"{Color.BOLD}Custom IOA Name{Color.END}",
+        "description": f"{Color.BOLD}Description{Color.END}",
+        "platform": f"{Color.BOLD}Platform{Color.END}",
+        "rules": f"{Color.BOLD}Rules{Color.END}"
+    }
+    ioas = []
+    for match in matches["body"]["resources"]:
+        ioa = {}
+        ioa["name"] = f"{match['name']}\n{Color.CYAN}{match['id']}{Color.END}\n{match['comment']}"
+        ioa["description"] = chunk_long_description(match["description"], 40)
+        if match["enabled"]:
+            enabled = f"{Color.GREEN}Enabled{Color.END}"
+        else:
+            enabled = f"{Color.LIGHTRED}Disabled{Color.END}"
+        platform = [f"{match['platform']}",
+                    f"{enabled}",
+                    f"Version: {Color.BOLD}{match['version']}{Color.END}"
+                    ]
+        ioa["platform"] = "\n".join(platform)
+        rules = [f"{rule['name']} (ver: {rule['instance_version']})" for rule in match["rules"]]
+        ioa["rules"] = "\n".join(rules)
+        ioas.append(ioa)
+
+    if not ioas:
+        fail = [
+            fr"{Color.BOLD}{Color.YELLOW}_  _ ____    ____ ____ ____ _  _ _    ___ ____",
+            r"|\ | |  |    |__/ |___ [__  |  | |     |  [__",
+            fr"| \| |__|    |  \ |___ ___] |__| |___  |  ___]{Color.END}"
+            ]
+        print("\n".join(fail))
+    else:
+        print("\n".join(banner))
+        print(tabulate(ioas, headers=headers, tablefmt=table_format))
+
+
+def duplicate_ioas(sdk: CustomIOA, matches: dict, filter_string: str = None):
+    """Duplicate all IOAs that match our provided filter."""
+    for rulegroup in matches["body"]["resources"]:
+        create = falcon.create_rule_group(name=f"{rulegroup['name']} clone",
+                                          description=rulegroup["description"],
+                                          comment=f"Cloned from Rule Group {rulegroup['id']}",
+                                          platform=rulegroup["platform"]
+                                          )
+        create_id = create["body"]["resources"][0]["id"]
+        print(f"Cloned rule group {rulegroup['name']} to new rule group {create_id}")
+        for rule in rulegroup["rules"]:
+            rule_body = {
+                "description": rule["description"],
+                "disposition_id": rule["disposition_id"],
+                "comment": "Cloned",
+                "field_values": rule["field_values"],
+                "pattern_severity": rule["pattern_severity"],
+                "name": f"Clone of {rule['name']}",
+                "rulegroup_id": create_id,
+                "ruletype_id": rule["ruletype_id"]
+            }
+            rule_create = falcon.create_rule(body=rule_body)
+            print(f"Cloned rule to new rule {rule_create['body']['resources'][0]['name']}")
+        print(f"Completed clone of rule group {rulegroup['name']}")
+
+    return get_ioa_list(sdk, filter_string)
+
+
+def delete_ioas(sdk: CustomIOA, ids_to_delete: str, filter_string: str = None):
+    """Delete all IOAs in the provided ID list."""
+    id_list = ids_to_delete.split(",")
+    delete_result = sdk.delete_rule_groups(ids=id_list)
+    if delete_result["status_code"] != 200:
+        for error in delete_result["body"]["errors"]:
+            ecode = f"{Color.LIGHTRED}{error['code']}{Color.END}"
+            emsg = f"{Color.YELLOW}{error['message']}{Color.END}"
+            print(f"\n{Color.BOLD}[{ecode}{Color.END}{Color.BOLD}] {emsg}")
+    else:
+        msg = "IOA rule group deleted"
+        print(
+            f"\n{Color.BOLD}[{Color.GREEN}200{Color.END}{Color.BOLD}] {msg}{Color.END}"
+            )
+    return get_ioa_list(sdk, filter_string)
+
+
+def monochrome():
+    """Disable color output."""
+    return [setattr(Color, item, "") for item in dir(Color) if "__" not in item]
+
+
+if __name__ == "__main__":
+    # Retrieve our command line
+    args = consume_arguments()
+    if args.nocolor:
+        # They don't want shiny, turn off the colors
+        monochrome()
+    # Create an instance of our Custom IOA Service Class
+    falcon = open_sdk(args.falcon_client_id, args.falcon_client_secret, args.base_url)
+    # Retrieve all IOA rule groups matching the provided filter
+    ioa_rules = get_ioa_list(falcon, args.filter)
+    if args.clone:
+        if args.filter:
+            # Clone any rule groups that match our filter
+            ioa_rules = duplicate_ioas(falcon, ioa_rules, args.filter)
+        else:
+            # Prevent them from cloning every IOA rule group within the tenant
+            fail_msg = f"{Color.YELLOW}You must specify a filter in order to clone rule groups"
+            print(
+                f"\n{Color.BOLD}[{Color.LIGHTRED}400{Color.END}{Color.BOLD}] {fail_msg}{Color.END}"
+            )
+    if args.delete:
+        # Delete any rule groups with IDs in the provided ID list
+        ioa_rules = delete_ioas(falcon, args.delete, args.filter)
+    # Display all IOA rule group matches in tabular format
+    show_ioas(ioa_rules, args.table_format)

--- a/samples/sensor_update_policies/policy_wonk.py
+++ b/samples/sensor_update_policies/policy_wonk.py
@@ -63,14 +63,14 @@ class Color:  # pylint: disable=R0903
     END = "\033[0m"
 
 
-def connect_sensor_update_api(key: str, sec: str, kid: str):
+def connect_sensor_update_api(key: str, sec: str, kid: str, base: str):
     """Connect to the sensor update policies service collection."""
-    return SensorUpdatePolicy(client_id=key, client_secret=sec, member_cid=kid)
+    return SensorUpdatePolicy(client_id=key, client_secret=sec, member_cid=kid, base_url=base)
 
 
-def connect_host_group_api(key: str, sec: str, kid: str):
+def connect_host_group_api(key: str, sec: str, kid: str, base: str):
     """Connect to the Host Group service collection."""
-    return HostGroup(client_id=key, client_secret=sec, member_cid=kid)
+    return HostGroup(client_id=key, client_secret=sec, member_cid=kid, base_url=base)
 
 
 def generate_api_error_list(error_object: list):
@@ -163,6 +163,9 @@ def consume_arguments():
     # MSSP
     msp = parser.add_argument_group("MSSP arguments")
     msp.add_argument("-w", "--member_cid", help="Child CID (MSSP access)", required=False)
+    # Other
+    oth = parser.add_argument_group("other arguments")
+    oth.add_argument("-t", "--base_url", help="Specify the API base URL", required=False)
     # Always required
     req = parser.add_argument_group("always required arguments")
     req.add_argument("-f", "--falcon_client_id", help="Falcon Client ID", required=True)
@@ -245,10 +248,14 @@ def process_command_line():  # pylint: disable=R0912,R0915
     mssp_access = None
     if args.member_cid:
         mssp_access = args.member_cid
+    
+    base_url = "auto"
+    if args.base_url:
+        base_url = args.base_url
 
     return command_to_perform, args.falcon_client_id, args.falcon_client_secret, args.search_string,\
         args.policy_id, update_type, flag_type, hide_members, args.platform_name, group_id,\
-        hide_groups, mssp_access
+        hide_groups, mssp_access, base_url
 
 
 def hide_members_column():
@@ -663,9 +670,9 @@ INDICATOR = ["|", "/", "-", "\\"]
 INDICATOR_POSITION = 0
 
 command, client_id, client_secret, API_SEARCH, policy_id, which_update, \
-    enable_disable, HIDE, platform_name, hg_id, GROUP_HIDE, member_cid = process_command_line()
-falcon = connect_sensor_update_api(client_id, client_secret, member_cid)
-falcon_groups = connect_host_group_api(client_id, client_secret, member_cid)
+    enable_disable, HIDE, platform_name, hg_id, GROUP_HIDE, member_cid, base_url = process_command_line()
+falcon = connect_sensor_update_api(client_id, client_secret, member_cid, base_url)
+falcon_groups = connect_host_group_api(client_id, client_secret, member_cid, base_url)
 
 if "kernel" in command:
     list_kernel_compatibility()

--- a/util/public-modules.sh
+++ b/util/public-modules.sh
@@ -19,11 +19,14 @@ y="\033[33m"
 g="\033[92m"
 p="\033[4m"
 o="\033[32m"
+bz="\033[34m"
 k="|"
 ub="Uber$e"
 ub="$g$ub"
+ax=" Auth$e"
+ax="$b$bz$ax"
 # If you squint, it looks just like a falcon. Honest.
-bf="$e     we stop"
+bf="$e     we$b stop$e"
 be="$o            \" \"$e"
 bd="$o         =^\`-'^="
 bc="$o          <$r*$o,$r*$o>"
@@ -66,11 +69,13 @@ n=$(wc -w <<< $a)
 az=" $p      MODULE                      "
 ab="     CLASS NAME                      METHODS $e"
 echo -e "$az$ab"
+tops=0
 for fn in $a
 do
     u=""
     t=$(($t+1))
     op=$(cat $fn | grep "(self:" | wc -l)
+    tops=$(($tops+$op))
     q=$(cat $fn | grep \(Service)
     q=${q/\(ServiceClass\):/}
     q=${q/class /}
@@ -83,6 +88,15 @@ do
     then
       u="           Uber"
       q="APIHarness"
+#    else
+#      if [ "$q" != "Iocs" ]
+#      then
+#	tops=$(($tops+$op))
+#      fi
+    fi
+    if [ ${fn/$fp$m\//} == oauth2.py ]
+    then
+      u="               Auth"
     fi
     if [ $t == $n ]
     then
@@ -92,8 +106,12 @@ do
     w=$(printf "%-35s" "$z")
     v=$(printf "%-28s" "$q $u")
     c=$(echo " $w | $v ")
-    echo -e "$k$j${c/Uber/$ub} |$op $e$k"
+    c=${c/Uber/$ub}
+    c=${c/\ Auth/$ax}
+    echo -e "$k$j$c |$op $e$k"
 done
+echo
+echo "$tops total methods"
 echo
 
 if [[ "$2" == *--egg* ]]


### PR DESCRIPTION
# Sample and Utility updates
This pull request implements the following:

- Adds support for `base_url` to the [Policy Wonk](https://github.com/CrowdStrike/falconpy/tree/main/samples/sensor_update_policies#manage-sensor-update-policies-with-policy-wonk) sample.
- Resolves an issue where the key list may be missing columns within the [`get_cspm_policies.py`](https://github.com/CrowdStrike/falconpy/blob/main/samples/cspm_registration/get_cspm_policies.py) sample.
- Adds a new sample, Custom IOA Cloner.
- Adds total methods returned display to the [`public-modules.sh`](https://github.com/CrowdStrike/falconpy/blob/main/util/public-modules.sh) utility.

* [x] Enhancement
* [x] Documentation
* [x] Code sample

#### Bandit analysis
```shell
[main]	INFO	running on Python 3.9.9
Run started:2022-07-04 16:32:06.598833

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 7135
	Total lines skipped (#nosec): 1

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```
## Added features and functionality
+ Add new sample: Custom IOA Cloner
    - `samples/custom_ioa/custom_ioa_clone.py`
+ Add: Base URL functionality to the Policy Wonk sample.
    - `samples/sensor_update_policies/policy_wonk.py`
+ Add: Add total methods returned display.
    - `util/public-modules.sh`

## Issues resolved
+ Fix: Error when calculating the list of available keys within the Get CSPM Policies sample.
    - `samples/cspm_registration/get_cspm_policies.py`

