### PR TITLE
https://github.com/CrowdStrike/falconpy/issues/708: check if content-…

### DIFF
--- a/src/falconpy/_util.py
+++ b/src/falconpy/_util.py
@@ -260,7 +260,7 @@ def perform_request(endpoint: str = "",  # pylint: disable=R0912
                                             )
 
                 returning_content_type = response.headers.get('content-type')
-                if returning_content_type == "application/json":
+                if returning_content_type.startswith("application/json"):
                     content_return = Result()(response.status_code, response.headers, response.json())
                 else:
                     content_return = response.content


### PR DESCRIPTION
…type header starts with 'application/json'

## parse json responses with charset included in header
When performing requests via the [perform_request](https://github.com/CrowdStrike/falconpy/blob/c5a19b8d6088810fa5cba7187dab871850706a16/src/falconpy/_util.py#L263) method It checks if content-type is application/json, and if so - return the json parsed response.
```
returning_content_type = response.headers.get('content-type')
if returning_content_type == "application/json":
    content_return = Result()(response.status_code, response.headers, response.json())
```
But when response's content-type has charset specification (i.e `content-type: application/json; charset=utf-8`) it ignores it and return the bytes content instead of a dict.
This PR checks for `application/json` prefix instead of exact match.

- [x] Bug fixes 

> Check the values above that match your PR and remove the remaining.

#### Unit test coverage
```shell
COVERAGE RESULTS SHOULD BE POSTED HERE
PLEASE REVIEW CONTRIBUTING.md FOR MORE
DETAILS ON GENERATING COVERAGE RESULTS
```

#### Bandit analysis
```shell
BANDIT ANALYSIS RESULTS SHOULD BE POSTED
HERE. PLEASE REVIEW CONTRIBUTING.md FOR
MORE DETAILS ON GENERATING BANDIT RESULTS
```
## Added features and functionality
Fixed a bug where content-type with charset such as `content-type: application/json; charset=utf-8` was ignored

## Issues resolved
* Fixes https://github.com/CrowdStrike/falconpy/issues/708 by Checking for content-type prefix instead of exact match.


