### PR TITLE
Add new Online Since, Host Group Duplicator samples

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -752,3 +752,4 @@ userActionV
 entitiesRolesV
 combinedUserRolesV
 NoneType
+Trueblood

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -33,6 +33,7 @@ These coders deserve accolades and laurels as well as cool titles and cartoons. 
 | Christophe Viaud, `@falcon-pioupiou` | [Consequence Substantiator](https://xkcd.com/1678/) |
 | Shane Shellenbarger, `@soggysec` | [Calamity Validator](https://xkcd.com/1700/) |
 | Timothy Sullivan, `@tsullivan06` | [Functionality Determinator](https://xkcd.com/1349/) |
+| Steve Klassen, `@mrxinu` | [Dilemma Respondent](https://xkcd.com/85/) |
 
 ## Contributors
 The following members of the community have made requests, suggestions, code contributions or provided feedback and reported bugs.
@@ -57,7 +58,6 @@ This has been a critical element in the development of the FalconPy project.
 + Kyle Cozad, `@cozadk`
 + `@sspencer-hubble`
 + `@t-lark`
-+ Steve Klassen, `@mrxinu`
 + Valerian Rossigneux, `@valerianrossigneux`
 + Kenny Mancuso, `@KennyOps`
 + `@morcef`

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -71,6 +71,7 @@ This has been a critical element in the development of the FalconPy project.
 + `@micgoetz`
 + Hod Alpert, `@hod-alpert`
 + `@mwilco03`
++ Glenn, `@hiddenillusion`
 
 ## Sponsors
 Without the support of these executives, the FalconPy project would not have happened.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -72,6 +72,7 @@ This has been a critical element in the development of the FalconPy project.
 + Hod Alpert, `@hod-alpert`
 + `@mwilco03`
 + Glenn, `@hiddenillusion`
++ Taylor Trueblood, `@Trueblood506`
 
 ## Sponsors
 Without the support of these executives, the FalconPy project would not have happened.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,13 @@ Once installed, you can immediately begin using CrowdStrike functionality in you
 """CrowdStrike FalconPy Quick Start."""
 from falconpy import Hosts
 
-hosts = Hosts(client_id="CROWDSTRIKE_API_CLIENT_ID", client_secret="CROWDSTRIKE_API_SECRET")
+# Use the API Clients and Keys page within your Falcon console to generate credentials.
+# You will need to assign the Hosts: READ scope to your client to run this example.
+
+# CrowdStrike does not recommend you hardcode credentials within source code.
+# Instead, provide these values as variables that are retrieved from the environment,
+# read from a file, provided at runtime, etc.
+hosts = Hosts(client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
 
 SEARCH_FILTER = "hostname-search-string"
 

--- a/samples/flight_control/host_group_duplicator.py
+++ b/samples/flight_control/host_group_duplicator.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+r"""Duplicate host groups from a parent down to the children.
+
+ _   _           _      ____                         ____              _ _           _
+| | | | ___  ___| |_   / ___|_ __ ___  _   _ _ __   |  _ \ _   _ _ __ | (_) ___ __ _| |_ ___  _ __
+| |_| |/ _ \/ __| __| | |  _| '__/ _ \| | | | '_ \  | | | | | | | '_ \| | |/ __/ _` | __/ _ \| '__|
+|  _  | (_) \__ \ |_  | |_| | | | (_) | |_| | |_) | | |_| | |_| | |_) | | | (_| (_| | || (_) | |
+|_| |_|\___/|___/\__|  \____|_|  \___/ \__,_| .__/  |____/ \__,_| .__/|_|_|\___\__,_|\__\___/|_|
+                                            |_|                 |_|
+
+
+"""
+from argparse import ArgumentParser, RawTextHelpFormatter
+from falconpy import HostGroup, FlightControl
+
+
+def create_host_group(sdk: HostGroup, gdesc: str, gtype: str, gname: str, arule: str):
+    """Create a host group within the tenant based upon provided keyword arguments."""
+    returned_id = None
+    create_response = sdk.create_host_groups(description=gdesc,
+                                             group_type=gtype,
+                                             name=gname,
+                                             assignment_rule=arule
+                                             )
+    if create_response["status_code"] == 409:
+        # Group already exists
+        print(f"Group {gname} already exists within this tenant.")
+
+    elif create_response["status_code"] != 201:
+        print(f"Unable to create group {gname} within this tenant.")
+    else:
+        returned_id = create_response["body"]["resources"][0]["id"]
+
+    return returned_id
+
+
+def consume_arguments():
+    """Consume any provided command line arguments."""
+    parser = ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
+    parser.add_argument("-k", "--falcon_client_id",
+                        help="CrowdStrike Falcon API Client ID",
+                        required=True
+                        )
+    parser.add_argument("-s", "--falcon_client_secret",
+                        help="CrowdStrike Falcon API Client secret",
+                        required=True
+                        )
+    parser.add_argument("-r", "--region",
+                        help="CrowdStrike Region (us1, us2, eu1, usgov1). Required for usgov1.",
+                        required=False,
+                        default="auto"
+                        )
+    parser.add_argument("-f", "--hostgroup_filter",
+                        help="String to use to search for host groups within the parent.",
+                        required=True
+                        )
+
+    return parser.parse_args()
+
+
+def get_host_group_matches(sdk: HostGroup, filter_string: str):
+    """Retrieve our parent groups to duplicate using our provided filter."""
+    result = sdk.query_combined_host_groups(filter=f"name:*'*{filter_string}*'")
+    if result["status_code"] != 200:
+        raise SystemExit("Unable to retrieve host group details from parent.")
+    if not result["body"]["resources"]:
+        raise SystemExit(
+            "No host groups identified within parent that match the provided search term."
+            )
+    return result["body"]["resources"]
+
+
+# MAIN ROUTINE
+args = consume_arguments()
+creds = {
+    "client_id": args.falcon_client_id,
+    "client_secret": args.falcon_client_secret
+}
+mssp = FlightControl(creds=creds, base_url=args.region)
+parent_groups = HostGroup(auth_object=mssp.auth_object)
+# Retrieve a list of children
+children = mssp.query_children()["body"]["resources"]
+if not children:
+    # No children found, crash out
+    raise SystemExit("No children found, are you using the correct API credentials?")
+
+# Get our list of groups to migrate
+host_groups_to_migrate = get_host_group_matches(parent_groups, args.hostgroup_filter)
+
+# Loop through all identified children
+for child in children:
+    creds["member_cid"] = child  # Set member_cid in the credentials dictionary
+    print(f"Tenant ID: {child}")
+    groups = HostGroup(creds=creds)
+    # Loop through all groups returned that match our filter
+    for group in host_groups_to_migrate:
+        # Create the group
+        group_id = create_host_group(sdk=groups,
+                                     gdesc=group["description"],
+                                     gtype=group["group_type"],
+                                     gname=group["name"],
+                                     arule=group["assignment_rule"]
+                                     )
+        if group_id:
+            print(f"Group {group_id} created.")
+    print(f"{'=' * 80}\n")

--- a/samples/hosts/online_since.py
+++ b/samples/hosts/online_since.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+r"""List the number of hosts within a tenant broken out by online duration.
+
+  ______   .__   __.  __       __  .__   __.  _______         _______. __  .__   __.   ______  _______
+ /  __  \  |  \ |  | |  |     |  | |  \ |  | |   ____|       /       ||  | |  \ |  |  /      ||   ____|
+|  |  |  | |   \|  | |  |     |  | |   \|  | |  |__         |   (----`|  | |   \|  | |  ,----'|  |__
+|  |  |  | |  . `  | |  |     |  | |  . `  | |   __|         \   \    |  | |  . `  | |  |     |   __|
+|  `--'  | |  |\   | |  `----.|  | |  |\   | |  |____    .----)   |   |  | |  |\   | |  `----.|  |____
+ \______/  |__| \__| |_______||__| |__| \__| |_______|   |_______/    |__| |__| \__|  \______||_______|
+
+This script is a modified version of a similar script developed by
+Trueblood506@CrowdStrike and is located here: https://github.com/Trueblood506/HostOnline
+"""
+import sys
+import logging
+from argparse import ArgumentParser, RawTextHelpFormatter
+import pandas as pd
+from falconpy import Hosts
+
+
+def retrieve_api_data(logger: logging.Logger, config: ArgumentParser):
+    """Retrieve hostname, first_seen and last_seen for every host in our tenant."""
+    logger.info("Connecting to API")
+    hosts = Hosts(client_id=config.falcon_client_id,
+                  client_secret=config.falcon_client_secret,
+                  base_url=config.base_url
+                  )
+    host_details = {}
+    offset = ""
+    total = 1
+    retrieved = 0
+    logger.info("Retrieving details for all available hosts")
+    while retrieved < total:
+        logger.debug("Querying API for hosts")
+        result = hosts.query_devices_by_filter_scroll(limit=5000, offset=offset, sort="hostname|asc")
+        page = result["body"]["meta"].get("pagination", {"total": 0})
+        total = page["total"]
+        if not total:
+            log.error("No hosts found")
+            raise SystemExit("\nProcess exited as no hosts were returned.")
+        offset = page["offset"]
+        total_returned = len(result["body"]["resources"])
+        retrieved += total_returned
+        logger.debug("Retrieved %i IDs (%i / %i)", total_returned, retrieved, total)
+        if result["body"]["resources"]:
+            detail = hosts.get_device_details(
+                        result["body"]["resources"]
+                        )["body"]["resources"]
+            for host in detail:
+                if host.get("first_seen", None) and host.get("last_seen", None):
+                    host_details[host["device_id"]] = {
+                        "hostname": host.get("hostname", "Unknown"),
+                        "last_seen": host.get("last_seen"),
+                        "first_seen": host.get("first_seen")
+                    }
+        logger.debug("Retrieved hostname, first_seen and last_seen for this %i hosts", total_returned)
+
+    logger.info("Retrieved details for a total of %i hosts", len(host_details))
+
+    return host_details
+
+
+def process_data(dataset: pd.DataFrame, logger: logging.Logger):
+    """Use pandas to quickly process our returned dataset."""
+    logger.info("Processing dataset")
+    dframe = pd.DataFrame().from_dict(dataset, orient="index")
+    logger.debug("Calculating differences")
+    difference = pd.to_datetime(dframe["last_seen"].values) - pd.to_datetime(dframe["first_seen"].values)
+    difference = difference.astype("timedelta64[h]")
+    difference = difference.values.tolist()
+    count = 0
+    count2 = 0
+    count3 = 0
+    count4 = 0
+    count5 = 0
+    count6 = 0
+    count7 = 0
+    count8 = 0
+    logger.debug("Processing difference results")
+    for i in difference:
+        if i < 1:
+            count8 += 1
+        elif i >= 720:
+            count7 += 1
+        elif i >= 168:
+            count6 += 1
+        elif i >= 24:
+            count5 += 1
+        elif i >= 8:
+            count4 += 1
+        elif i >= 4:
+            count3 += 1
+        elif i >= 2:
+            count2 += 1
+        elif i >= 1:
+            count += 1
+    return count8, count, count2, count3, count4, count5, count6, count7
+
+
+def logger_setup(config: ArgumentParser):
+    """Create a log utility to show results."""
+    logging.basicConfig(stream=sys.stdout, format='%(levelname)-8s%(message)s')
+    log_device = logging.getLogger("online_since")
+    log_level = logging.INFO
+    if str(config.log_level).upper() == "DEBUG" or str(config.log_level).upper().startswith("D"):
+        log_level = logging.DEBUG
+    log_device.setLevel(log_level)
+    return log_device
+
+
+def show_result(data_to_process: dict, log_utility: logging.Logger):
+    """Use the log utility to show the results of our processed data."""
+    results = process_data(data_to_process, log_utility)
+    log_utility.info("There are %i devices that have been online for less than 1 hour.", results[0])
+    log_utility.info("There are %i devices that have been online for more than 1 hour.", results[1])
+    log_utility.info("There are %i devices that have been online for more than 2 hours.", results[2])
+    log_utility.info("There are %i devices that have been online for more than 4 hours.", results[3])
+    log_utility.info("There are %i devices that have been online for more than 8 hours.", results[4])
+    log_utility.info("There are %i devices that have been online for more than 24 hours.", results[5])
+    log_utility.info("There are %i devices that have been online for at least a week.", results[6])
+    log_utility.info("There are %i devices that have been online for at least a month.", results[7])
+
+
+def consume_arguments():
+    """Consume and return any provided command line arguments."""
+    parser = ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
+    parser.add_argument("-k", "--falcon_client_id", help="CrowdStrike API Client ID", required=True)
+    parser.add_argument("-s", "--falcon_client_secret", help="CrowdStrike API Client Secret", required=True)
+    parser.add_argument("-b", "--base_url",
+                        help="CrowdStrike Falcon Base URL (only required for GovCloud)",
+                        default="auto",
+                        required=False
+                        )
+    parser.add_argument("-l", "--log_level", help="Logging level (debug, info)", default="info", required=False)
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = consume_arguments()
+    log = logger_setup(args)
+    api_data = retrieve_api_data(log, args)
+    show_result(api_data, log)


### PR DESCRIPTION
# New Samples
This update provides two new samples:
* Online Since - display host counts within a tenant by online duration.
* Host Group Duplicator - duplicate host groups from a parent to all children within a tenant.

- [x] Code sample

#### Unit test coverage
```shell
Not required for sample submissions.
```

#### Bandit analysis
```shell
[main]	INFO	running on Python 3.9.9
Run started:2022-09-13 05:36:50.218662

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 7896
	Total lines skipped (#nosec): 1

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```
## Added features and functionality
+ Added: Online Since sample
    - `samples/hosts/online_since.py`
    - Thanks to @Trueblood506 for contributing this new sample!  :bow:

+ Added: Host Group Duplicator
    - `samples/flight_control/host_group_duplicator.py`

## Other
+ Update Authors listing.

