### PR TITLE
[DRAFT] Scaffolding an Alternative Authentication Backend System

### DIFF
--- a/src/falconpy/_auth_object.py
+++ b/src/falconpy/_auth_object.py
@@ -27,6 +27,7 @@ class FalconPyAuth(ABC):
     This class is not usable by developers alone. You must expect to work with
     a derivative of this class, such as an OAuth2 object.
     """
+
     @property
     @abstractmethod
     def auth_headers(self) -> Dict[str, str]:
@@ -34,7 +35,7 @@ class FalconPyAuth(ABC):
 
         This function will always return a dictionary (which could be empty), containing
         all the HTTP headers required to authenticate a request. For example, an OAuth2
-        implementation of this class should return a dictionary containing a 
+        implementation of this class should return a dictionary containing a
         key -> value pair of the Authorization header and a Bearer token.
 
         If the headers need renewed data, such as updated tokens that can expire, the logic

--- a/src/falconpy/_auth_object.py
+++ b/src/falconpy/_auth_object.py
@@ -18,7 +18,7 @@ from abc import (
     ABC,
     abstractmethod,
 )
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 class FalconPyAuth(ABC):
@@ -54,3 +54,17 @@ class FalconPyAuth(ABC):
 
         This function may return any reasonable type, such as a dictionary.
         """
+
+    def __init__(
+        self,
+        base_url: str,
+        ssl_verify: bool = True,
+        timeout: int = 30,
+        proxy: Optional[Dict[str, str]] = None,
+        user_agent: str = None,
+    ):
+        self.base_url = base_url
+        self.ssl_verify = ssl_verify
+        self.timeout = timeout
+        self.proxy = proxy
+        self.user_agent = user_agent

--- a/src/falconpy/_auth_object.py
+++ b/src/falconpy/_auth_object.py
@@ -1,0 +1,55 @@
+"""Authentication Object Base Class.
+
+ _______                        __ _______ __        __ __
+|   _   .----.-----.--.--.--.--|  |   _   |  |_.----|__|  |--.-----.
+|.  1___|   _|  _  |  |  |  |  _  |   1___|   _|   _|  |    <|  -__|
+|.  |___|__| |_____|________|_____|____   |____|__| |__|__|__|_____|
+|:  1   |                         |:  1   |
+|::.. . |   CROWDSTRIKE FALCON    |::.. . |    FalconPy
+`-------'                         `-------'
+
+This file contains the definition of the base class that provides the necessary
+functions to authenticate to the API. Out of the box we will provide only one
+authentication object implementation in OAuth2.py, but this structure provides
+both future extensibility, as well as the ability to reason about encapsulation of
+authentication data.
+"""
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from typing import Any, Dict
+
+
+class FalconPyAuth(ABC):
+    """Abstract class to provide authentication to Falcon.
+
+    This class is not usable by developers alone. You must expect to work with
+    a derivative of this class, such as an OAuth2 object.
+    """
+    @property
+    @abstractmethod
+    def auth_headers(self) -> Dict[str, str]:
+        """Get a dictionary of headers that can authenticate an HTTP request.
+
+        This function will always return a dictionary (which could be empty), containing
+        all the HTTP headers required to authenticate a request. For example, an OAuth2
+        implementation of this class should return a dictionary containing a 
+        key -> value pair of the Authorization header and a Bearer token.
+
+        If the headers need renewed data, such as updated tokens that can expire, the logic
+        required for this should either be implemented or called from this function. Code
+        dependent on this function should not need to check token validity.
+        """
+
+    @property
+    @abstractmethod
+    def authenticated(self) -> bool:
+        """Read-only property can will return whether authentication is complete."""
+
+    @abstractmethod
+    def logout(self) -> Any:
+        """Log out of Falcon, such as by revoking a token.
+
+        This function may return any reasonable type, such as a dictionary.
+        """

--- a/src/falconpy/_service_class.py
+++ b/src/falconpy/_service_class.py
@@ -38,7 +38,7 @@ For more information, please refer to <https://unlicense.org>
 from __future__ import annotations
 import inspect
 
-from typing import Type
+from typing import Dict, Type
 
 from ._auth_object import FalconPyAuth
 from .oauth2 import OAuth2
@@ -95,7 +95,7 @@ class ServiceClass:
 
         This method only accepts keywords to specify arguments.
         """
-        self.headers = kwargs.get("ext_headers", {})
+        self.ext_headers = kwargs.get("ext_headers", {})
         # Currently defaulting to validation enabled
         self.validate_payloads = kwargs.get("validate_payloads", True)
         self.auth_object: FalconPyAuth = None
@@ -103,13 +103,16 @@ class ServiceClass:
         # Passing an auth_object will automatically ignore the rest of the parameters, as
         # this can be treated as an atomic collection of all authentication information.
         if auth_object:
-            if issubclass(type(FalconPyAuth), auth_object):
+            if issubclass(type(auth_object), FalconPyAuth):
                 self.auth_object = auth_object
             else:
                 # Look for an OAuth2 object as an attribute to the object they provided.
                 for attr in [x for x in dir(auth_object) if "__" not in x]:
                     if attr == "auth_object":
                         self.auth_object = auth_object.auth_object
+
+            if self.auth_object is None:
+                raise Exception("Unknown auth_object passed")
 
         else:
             # Get all the arguments of the authentication class's constructor
@@ -128,3 +131,31 @@ class ServiceClass:
     def token_expired(self) -> bool:
         """Return a boolean reflecting token expiration status."""
         return not self.authenticated
+
+    @property
+    def headers(self) -> Dict[str, str]:
+        """Provide a combination of headers needed for auth and additional supplied headers."""
+        return {
+            ** self.auth_object.auth_headers,
+            ** self.ext_headers,
+        }
+
+    @property
+    def base_url(self) -> str:
+        """Provide the base_url to legacy code that reads it straight from the service class."""
+        return self.auth_object.base_url
+
+    @base_url.setter
+    def base_url(self, value: str):
+        """Set the base_url in the underlying auth_object."""
+        self.auth_object.base_url = value
+
+    @property
+    def ssl_verify(self) -> bool:
+        """Provide the ssl_verify value to legacy code."""
+        return self.auth_object.ssl_verify
+
+    @ssl_verify.setter
+    def ssl_verify(self, value: bool):
+        """Allow legacy code to flip the SSL verify flag in the auth_object via the this class."""
+        self.auth_object.ssl_verify = value

--- a/src/falconpy/_service_class.py
+++ b/src/falconpy/_service_class.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """ServiceClass base class.
 
  _______                        __ _______ __        __ __
@@ -35,7 +36,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
-from ._util import confirm_base_url, autodiscover_region
+import inspect
+
+from typing import Type
+
+from ._auth_object import FalconPyAuth
 from .oauth2 import OAuth2
 
 # pylint: disable=R0902  # Nine is reasonable
@@ -46,9 +51,12 @@ from .oauth2 import OAuth2
 class ServiceClass:
     """Base class of all service classes. Contains the default __init__ method."""
 
-    def __init__(self: object, auth_object: object = None,
-                 creds: dict = None, base_url: str = "https://api.crowdstrike.com",
-                 proxy: dict = None, **kwargs) -> object:
+    def __init__(
+        self: object,
+        auth_object: FalconPyAuth = None,
+        default_auth_object_class: Type[FalconPyAuth] = OAuth2,
+        **kwargs,
+    ):
         """Service Class base constructor.
 
         Instantiates the object, ingests authorization credentials,
@@ -57,7 +65,12 @@ class ServiceClass:
         Keyword arguments:
         access_token: Token string to use for all requests performed.
                         Mutually exclusive to all other authentication elements.
-        auth_object: Properly authenticated instance of the OAuth2 Authentication service class.
+        auth_object: Properly authenticated instance of an authentication backend, such as
+                     the OAuth2 Authentication service class.
+        ext_headers: Additional headers to be prepended to the default headers dictionary.
+                     Dictionary.
+
+        # to be removed
         base_url: CrowdStrike API URL to use for requests. [Default: US-1]
         ssl_verify: Boolean specifying if SSL verification should be used. [Default: True]
         proxy: Dictionary of proxies to be used for requests.
@@ -79,110 +92,40 @@ class ServiceClass:
         renew_window: Amount of time (in seconds) between now and the token expiration before
                       a refresh of the token is performed. Default: 120, Max: 1200
                       Values over 1200 will be reset to the maximum.
-        ext_headers: Additional headers to be prepended to the default headers dictionary.
-                     Dictionary.
+        
 
         This method only accepts keywords to specify arguments.
         """
-        access_token = kwargs.get("access_token", None)
-        self.ssl_verify = kwargs.get("ssl_verify", True)
-        self.timeout = kwargs.get("timeout", None)
-        self.token_renew_window = kwargs.get("renew_window", 120)
-        user_agent = kwargs.get("user_agent", None)
-        member_cid = kwargs.get("member_cid", None)
         self.headers = kwargs.get("ext_headers", {})
         # Currently defaulting to validation enabled
         self.validate_payloads = kwargs.get("validate_payloads", True)
-        self.refreshable = False
-        self.token_fail_reason = None
-        self.token_status = None
-        self.auth_object = None
-        client_id = kwargs.get("client_id", None)
-        client_secret = kwargs.get("client_secret", None)
-        if client_id and client_secret and not creds:
-            # Passing client_id and client_secret will not
-            # overwrite the contents of the creds dictionary
-            creds = {
-                "client_id": client_id,
-                "client_secret": client_secret
-            }
-            if member_cid:
-                # Passing member_cid will not overwrite the
-                # existing value in the creds dictionary
-                creds["member_cid"] = member_cid
+        self.auth_object: FalconPyAuth = None
+
+        # Passing an auth_object will automatically ignore the rest of the parameters, as
+        # this can be treated as an atomic collection of all authentication information.
         if auth_object:
-            # Assume they've passed us an OAuth2 object
-            self.auth_object = auth_object
-            if not isinstance(auth_object, OAuth2):
-                # If they didn't, look for one as an attribute to the object they provided.
+            if issubclass(auth_object, FalconPyAuth):
+                self.auth_object = auth_object
+            else:
+                # Look for an OAuth2 object as an attribute to the object they provided.
                 for attr in [x for x in dir(auth_object) if "__" not in x]:
                     if attr == "auth_object":
                         self.auth_object = auth_object.auth_object
-            if not self.authenticated():
-                token_result = self.auth_object.token()
-                self.token_status = token_result["status_code"]
-                if self.token_status == 201:
-                    self.token = token_result["body"]["access_token"]
-                    self.headers["Authorization"] = f"Bearer {self.token}"
-                else:
-                    self.token = False
-                    self.token_fail_reason = self.auth_object.token_fail_reason
-            else:
-                self.token = self.auth_object.token_value
-                self.headers["Authorization"] = f"Bearer {self.token}"
 
-            self.base_url = auth_object.base_url
-            self.ssl_verify = auth_object.ssl_verify
-            self.proxy = auth_object.proxy
-            # Supports overriding user-agent per class
-            if not user_agent:
-                self.user_agent = auth_object.user_agent
-            else:
-                self.user_agent = user_agent
-            # At this point in time, you cannot override
-            # the auth_object's timeout per class instance
-            self.timeout = auth_object.timeout
-            self.refreshable = True
         else:
-            confirmed_base = confirm_base_url(base_url)
-            self.base_url = confirmed_base
-            if creds:
-                self.auth_object = OAuth2(creds=creds,
-                                          base_url=confirmed_base,
-                                          proxy=proxy,
-                                          ssl_verify=self.ssl_verify,
-                                          timeout=self.timeout,
-                                          user_agent=user_agent,
-                                          renew_window=self.token_renew_window
-                                          )
-                token_result = self.auth_object.token()
-                self.token_status = token_result["status_code"]
-                if self.token_status == 201:
-                    self.token = token_result["body"]["access_token"]
-                    self.headers["Authorization"] = f"Bearer {self.token}"
-                    self.base_url = autodiscover_region(confirmed_base, token_result)
-                else:
-                    self.token = False
-                    self.token_fail_reason = self.auth_object.token_fail_reason
-                self.refreshable = True
-            else:
-                self.headers["Authorization"] = f"Bearer {access_token}"
+            # Get all the arguments of the authentication class's constructor 
+            auth_object_class_sig = inspect.signature(default_auth_object_class)
+            auth_kwargs = {}
+            for param in auth_object_class_sig.parameters:
+                if param in kwargs:
+                    auth_kwargs[param] = kwargs[param]
 
-            self.proxy = proxy
-            self.user_agent = user_agent
+            self.auth_object = default_auth_object_class(**auth_kwargs)
 
-    def authenticated(self):
+    def authenticated(self) -> bool:
         """Return the current authentication status."""
-        result = None
-        if self.auth_object:
-            result = self.auth_object.authenticated()
+        return self.auth_object.authenticated
 
-        return result
-
-    def token_expired(self):
+    def token_expired(self) -> bool:
         """Return a boolean reflecting token expiration status."""
-        result = None
-        if self.auth_object:
-            result = self.auth_object.token_expired()
-
-        return result
+        return not self.authenticated

--- a/src/falconpy/_service_class.py
+++ b/src/falconpy/_service_class.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 """ServiceClass base class.
 
  _______                        __ _______ __        __ __
@@ -36,6 +35,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
+from __future__ import annotations
 import inspect
 
 from typing import Type
@@ -92,7 +92,6 @@ class ServiceClass:
         renew_window: Amount of time (in seconds) between now and the token expiration before
                       a refresh of the token is performed. Default: 120, Max: 1200
                       Values over 1200 will be reset to the maximum.
-        
 
         This method only accepts keywords to specify arguments.
         """
@@ -113,7 +112,7 @@ class ServiceClass:
                         self.auth_object = auth_object.auth_object
 
         else:
-            # Get all the arguments of the authentication class's constructor 
+            # Get all the arguments of the authentication class's constructor
             auth_object_class_sig = inspect.signature(default_auth_object_class)
             auth_kwargs = {}
             for param in auth_object_class_sig.parameters:

--- a/src/falconpy/_service_class.py
+++ b/src/falconpy/_service_class.py
@@ -103,7 +103,7 @@ class ServiceClass:
         # Passing an auth_object will automatically ignore the rest of the parameters, as
         # this can be treated as an atomic collection of all authentication information.
         if auth_object:
-            if issubclass(FalconPyAuth, auth_object):
+            if issubclass(type(FalconPyAuth), auth_object):
                 self.auth_object = auth_object
             else:
                 # Look for an OAuth2 object as an attribute to the object they provided.

--- a/src/falconpy/_service_class.py
+++ b/src/falconpy/_service_class.py
@@ -103,7 +103,7 @@ class ServiceClass:
         # Passing an auth_object will automatically ignore the rest of the parameters, as
         # this can be treated as an atomic collection of all authentication information.
         if auth_object:
-            if issubclass(auth_object, FalconPyAuth):
+            if issubclass(FalconPyAuth, auth_object):
                 self.auth_object = auth_object
             else:
                 # Look for an OAuth2 object as an attribute to the object they provided.

--- a/src/falconpy/_util.py
+++ b/src/falconpy/_util.py
@@ -35,11 +35,12 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to <https://unlicense.org>
 """
+from __future__ import annotations
 import base64
 import functools
 
 from json.decoder import JSONDecodeError
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
 
 import requests
 import urllib3
@@ -48,9 +49,11 @@ from ._version import _TITLE, _VERSION
 from ._result import Result, ExpandedResult
 from ._base_url import BaseURL
 from ._container_base_url import ContainerBaseURL
-from ._service_class import ServiceClass
 from ._uber_default_preference import PREFER_NONETYPE, MOCK_OPERATIONS
 urllib3.disable_warnings(InsecureRequestWarning)
+
+if TYPE_CHECKING:
+    from ._service_class import ServiceClass
 
 # Restrict requests to only allowed HTTP methods
 _ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'UPDATE']

--- a/src/falconpy/_util.py
+++ b/src/falconpy/_util.py
@@ -45,11 +45,13 @@ from typing import Dict, TYPE_CHECKING
 import requests
 import urllib3
 from urllib3.exceptions import InsecureRequestWarning
-from ._version import _TITLE, _VERSION
-from ._result import Result, ExpandedResult
+
+from ._auth_object import FalconPyAuth
 from ._base_url import BaseURL
 from ._container_base_url import ContainerBaseURL
+from ._result import Result, ExpandedResult
 from ._uber_default_preference import PREFER_NONETYPE, MOCK_OPERATIONS
+from ._version import _TITLE, _VERSION
 urllib3.disable_warnings(InsecureRequestWarning)
 
 if TYPE_CHECKING:
@@ -161,13 +163,7 @@ def force_default(defaults: list, default_types: list = None):
 
 def service_request(caller: ServiceClass = None, **kwargs) -> object:  # May return dict or object datatypes
     """Check for token expiration, refresh if possible and then perform the request."""
-    headers: Dict[str, str] = kwargs['headers']
     if caller:
-        try:
-            headers.update(caller.auth_object.auth_headers)
-        except AttributeError:
-            pass
-
         try:
             proxy: Dict[str, str] = caller.auth_object.proxy
         except AttributeError:
@@ -187,7 +183,7 @@ def service_request(caller: ServiceClass = None, **kwargs) -> object:  # May ret
         proxy=proxy,
         timeout=timeout,
         user_agent=user_agent,
-        headers=headers,
+        # headers=headers,
         **kwargs,
     )
 
@@ -411,11 +407,18 @@ def process_service_request(calling_object: object,  # pylint: disable=R0914 # (
     expand_result -- Request expanded results output
     """
     target_endpoint = [ep for ep in endpoints if operation_id == ep[0]][0]
-    base_url = calling_object.base_url
+    if issubclass(type(calling_object), type(FalconPyAuth)):
+        auth_object: FalconPyAuth = calling_object
+    elif hasattr(calling_object, 'auth_object'):
+        auth_object: FalconPyAuth = calling_object.auth_object
+    else:
+        raise Exception("Could not locate an auth_object to extract a base_url from")
+
+    base_url = auth_object.base_url
     container = False
     if operation_id in MOCK_OPERATIONS:
         for base in [burl for burl in dir(BaseURL) if "__" not in burl]:
-            if BaseURL[base].value == calling_object.base_url.replace("https://", ""):
+            if BaseURL[base].value == auth_object.base_url.replace("https://", ""):
                 base_url = f"https://{ContainerBaseURL[base].value}"
                 container = True
     target_url = f"{base_url}{target_endpoint[2]}"
@@ -441,7 +444,7 @@ def process_service_request(calling_object: object,  # pylint: disable=R0914 # (
         "caller": calling_object,
         "method": target_method,
         "endpoint": target_url,
-        "verify": calling_object.ssl_verify,
+        "verify": calling_object.auth_object.ssl_verify,
         "headers": passed_headers,
         "params": parameter_payload,
         "body": kwargs.get("body", None),

--- a/src/falconpy/_util.py
+++ b/src/falconpy/_util.py
@@ -37,7 +37,10 @@ For more information, please refer to <https://unlicense.org>
 """
 import base64
 import functools
+
 from json.decoder import JSONDecodeError
+from typing import Dict
+
 import requests
 import urllib3
 from urllib3.exceptions import InsecureRequestWarning
@@ -45,6 +48,7 @@ from ._version import _TITLE, _VERSION
 from ._result import Result, ExpandedResult
 from ._base_url import BaseURL
 from ._container_base_url import ContainerBaseURL
+from ._service_class import ServiceClass
 from ._uber_default_preference import PREFER_NONETYPE, MOCK_OPERATIONS
 urllib3.disable_warnings(InsecureRequestWarning)
 
@@ -152,36 +156,37 @@ def force_default(defaults: list, default_types: list = None):
     return wrapper
 
 
-def service_request(caller: object = None, **kwargs) -> object:  # May return dict or object datatypes
+def service_request(caller: ServiceClass = None, **kwargs) -> object:  # May return dict or object datatypes
     """Check for token expiration, refresh if possible and then perform the request."""
+    headers: Dict[str, str] = kwargs['headers']
     if caller:
         try:
-            if caller.auth_object:
-                if caller.auth_object.token_expired():
-                    auth_response = caller.auth_object.token()
-                    if auth_response["status_code"] == 201:
-                        caller.headers['Authorization'] = f"Bearer {auth_response['body']['access_token']}"
-                    else:
-                        caller.headers['Authorization'] = "Bearer "
+            headers.update(caller.auth_object.auth_headers)
         except AttributeError:
             pass
 
         try:
-            proxy = caller.proxy
+            proxy: Dict[str, str] = caller.auth_object.proxy
         except AttributeError:
             proxy = None
 
         try:
-            timeout = caller.timeout
+            timeout: int = caller.auth_object.timeout
         except AttributeError:
             timeout = None
 
         try:
-            user_agent = caller.user_agent
+            user_agent: str = caller.auth_object.user_agent
         except AttributeError:
             user_agent = None
 
-    returned = perform_request(proxy=proxy, timeout=timeout, user_agent=user_agent, **kwargs)
+    returned = perform_request(
+        proxy=proxy,
+        timeout=timeout,
+        user_agent=user_agent,
+        headers=headers,
+        **kwargs,
+    )
 
     return returned
 

--- a/src/falconpy/oauth2.py
+++ b/src/falconpy/oauth2.py
@@ -162,6 +162,7 @@ class OAuth2(FalconPyAuth):
 
     @property
     def token_expired(self) -> bool:
+        """Return whether the token is ready to be renewerd."""
         return (time.time() - self.token_time) >= (self.token_expiration - self.token_renew_window)
 
     def revoke(self: object, token: str) -> dict:
@@ -193,6 +194,7 @@ class OAuth2(FalconPyAuth):
 
     @property
     def auth_headers(self) -> Dict[str, str]:
+        """Return a Bearer token baked into an Authorization header ready for an HTTP request."""
         self.token()
 
         return {
@@ -201,9 +203,11 @@ class OAuth2(FalconPyAuth):
 
     @property
     def authenticated(self) -> bool:
+        """Return whether we are authentication (i.e., token is not expired)."""
         return not self.token_expired
 
     def logout(self) -> Dict:
+        """Revoke the token."""
         return self.revoke(self.token_value)
 
     # These method names align to the operation IDs in the API but

--- a/src/falconpy/oauth2.py
+++ b/src/falconpy/oauth2.py
@@ -90,6 +90,13 @@ class OAuth2(FalconPyAuth):
 
         This method only supports keywords to specify arguments.
         """
+        super().__init__(
+            base_url=confirm_base_url(base_url),
+            ssl_verify=ssl_verify,
+            timeout=timeout,
+            proxy=proxy,
+            user_agent=user_agent,
+        )
         if client_id and client_secret and not creds:
             creds = {
                 "client_id": client_id,
@@ -103,11 +110,6 @@ class OAuth2(FalconPyAuth):
             creds = {}
 
         self.creds: Dict[str, str] = creds
-        self.base_url: str = confirm_base_url(base_url)
-        self.ssl_verify: bool = ssl_verify
-        self.timeout: int = timeout
-        self.proxy: Dict[str, str] = proxy
-        self.user_agent: str = user_agent
         self.token_expiration: int = 0
         # Maximum renewal window is 20 minutes, Minimum is 2 minutes
         self.token_renew_window: int = max(min(renew_window, 1200), 120)

--- a/src/falconpy/oauth2.py
+++ b/src/falconpy/oauth2.py
@@ -36,6 +36,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <https://unlicense.org>
 """
 import time
+from typing import Dict, Optional
+
+from ._auth_object import FalconPyAuth
+from ._endpoint._oauth2 import _oauth2_endpoints as Endpoints
+from ._token_fail_reason import TokenFailReason
 from ._util import (
     perform_request,
     generate_b64cred,
@@ -43,11 +48,9 @@ from ._util import (
     generate_error_result,
     autodiscover_region,
     )
-from ._token_fail_reason import TokenFailReason
-from ._endpoint._oauth2 import _oauth2_endpoints as Endpoints
 
 
-class OAuth2:
+class OAuth2(FalconPyAuth):
     """To create an instance of this class, you must pass your client_id and client_secret.
 
     OR a properly formatted dictionary containing your client_id and client_secret
@@ -99,23 +102,19 @@ class OAuth2:
         elif not creds:
             creds = {}
 
-        self.creds = creds
-        self.base_url = confirm_base_url(base_url)
-        self.ssl_verify = ssl_verify
-        self.timeout = timeout
-        self.proxy = proxy
-        self.user_agent = user_agent
-        self.token_expiration = 0
+        self.creds: Dict[str, str] = creds
+        self.base_url: str = confirm_base_url(base_url)
+        self.ssl_verify: bool = ssl_verify
+        self.timeout: int = timeout
+        self.proxy: Dict[str, str] = proxy
+        self.user_agent: str = user_agent
+        self.token_expiration: int = 0
         # Maximum renewal window is 20 minutes, Minimum is 2 minutes
-        self.token_renew_window = max(min(renew_window, 1200), 120)
-        self.token_time = time.time()
-        self.token_value = False
-        self.token_expired = lambda: bool(
-            (time.time() - self.token_time) >= (self.token_expiration - self.token_renew_window)
-            )
-        self.token_fail_reason = None
-        self.token_status = None
-        self.authenticated = lambda: not bool(self.token_expired())
+        self.token_renew_window: int = max(min(renew_window, 1200), 120)
+        self.token_time: float = time.time()
+        self.token_value: Optional[str] = None
+        self.token_fail_reason: Optional[str] = None
+        self.token_status: Optional[int] = None
 
     def token(self: object) -> dict:
         """Generate an authorization token.
@@ -161,6 +160,10 @@ class OAuth2:
 
         return returned
 
+    @property
+    def token_expired(self) -> bool:
+        return (time.time() - self.token_time) >= (self.token_expiration - self.token_renew_window)
+
     def revoke(self: object, token: str) -> dict:
         """Revoke the specified authorization token.
 
@@ -182,11 +185,26 @@ class OAuth2:
                                        proxy=self.proxy, timeout=self.timeout,
                                        user_agent=self.user_agent)
             self.token_expiration = 0
-            self.token_value = False
+            self.token_value = None
         else:
             returned = generate_error_result("Invalid credentials specified", 403)
 
         return returned
+
+    @property
+    def auth_headers(self) -> Dict[str, str]:
+        self.token()
+
+        return {
+            'Authorization': 'Bearer ' + self.token_value,
+        }
+
+    @property
+    def authenticated(self) -> bool:
+        return not self.token_expired
+
+    def logout(self) -> Dict:
+        return self.revoke(self.token_value)
 
     # These method names align to the operation IDs in the API but
     # do not conform to snake_case / PEP8 and are defined here for


### PR DESCRIPTION
## An Alternative Approach to Authentication State Management
This is the untested, very early beginnings of a response to #829. It is not intended to work right now, and it is entirely untested, but is designed instead to suggest what an alternative may look like.

I have designed this to be a (mostly?) non-breaking change. The overall idea is that `OAuth2` can be one of an infinite number of authentication backends available, and each one should implement the `FalconPyAuth` abstract base class. I have put some hackery in `_service_class.py` which effectively shoves all of the `kwargs` passed to a service class down to a brand new `auth_object`, provided that the developer has not already built an `auth_object` of their own.

A FalconPyAuth class should implement a very basic number of properties / functions for now:
- `auth_headers`, a read-only property that will return a dictionary of headers (such as `Authorization`: `Bearer ...`) needed to authenticate
- `authenticated`, a `bool` which will let you know if we are currently authenticated. I am in two minds about whether this is needed (as you should be authenticated by virtue of configuring the derivative object of `FalconPyAuth`), but I can imagine some use cases in which this may not be the case.
- `logout`, a method that will perform whatever summative actions are needed. In the case of `OAuth2`, this would trigger a token revocation.

As I think is clear above, this is very much a work in progress, but I am publishing this with the intention of starting a discussion around what might make sense. It's definitely a bug that needs addressing, and I think we can tighten up a lot of code in doing so, but by doing this in the public domain we have the opportunity to hear from any customers that this might break things for.

Note that I am not actually enamoured with the implementation of some parts of this approach (especially the hackery to jam the `kwargs` down the chain into an `auth_object`), but I _think_ it might be the only way we can make this work without breaking changes. Right now, it's valid to assume that a `ServiceClass` can handle authentication for you, sans an `auth_object`, so we need a way to chuck that data down the chain in a generic way without maintaining some "shadow" authentication state in the service class itself.

- [X] Enhancement
- [X] Major Feature update
- [ ] Bug fixes 
- [ ] Breaking Change
- [ ] Updated unit tests
- [ ] Documentation
- [ ] Code sample

## Issues resolved
This would address #829 by ensuring state is maintained in one place only