### PR TITLE
Correct file naming when -n1 or -n2. Fixes #853

### DIFF
--- a/samples/sensor_download/download_sensor.py
+++ b/samples/sensor_download/download_sensor.py
@@ -233,14 +233,14 @@ elif CMD in "download":
                 plat_spec = sensor["platform"]
                 if plat_spec:
                     sha_to_retrieve = version_detail[plat_spec][full_name][NMVER]["sha256"]
+                    dl_desc = version_detail[plat_spec][full_name][NMVER]['description']
+                    dl_ver = version_detail[plat_spec][full_name][NMVER]['version']
                     if not FILENAME:
                         fname = version_detail[plat_spec][full_name][NMVER]["name"]
                         if sensor["os"] in ["Windows", "macOS"]:
-                            fname = f"{fname[:-4]}_{sensor['version']}{fname[len(fname)-4:]}"
+                            fname = f"{fname[:-4]}_{dl_ver}{fname[len(fname)-4:]}"
                     else:
                         fname=FILENAME
-                    dl_desc = version_detail[plat_spec][full_name][NMVER]['description']
-                    dl_ver = version_detail[plat_spec][full_name][NMVER]['version']
                     print(f"Downloading {dl_desc} version {dl_ver}")
                     download = falcon.command(
                         action="DownloadSensorInstallerById",


### PR DESCRIPTION
# Update Sensor Download sample
This update resolves a naming issue when downloading a n-1 or n-2 version sensor using the Sensor Download sample.

- [x] Bug fixes 
- [x] Code sample

#### Unit test coverage
```shell
NOT REQUIRED FOR SAMPLE SUBMISSIONS
```

#### Bandit analysis
```shell
[main]	INFO	running on Python 3.9.9

Run started:2022-12-12 20:08:50.994022

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 9758
	Total lines skipped (#nosec): 2

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```

## Issues resolved
+ Fixed: N-1 and N-2 sensor downloads are downloading with the incorrect filename (Sensor Download sample). Closes #853.
    - `samples/sensor_download/download_sensor.py`
    - Thanks go out to @iamfromit for identifying this issue and contributing the fix! 🙇 
