### PR TITLE
fix: propagate aut object credentials to uber class

### DIFF
--- a/src/falconpy/_util.py
+++ b/src/falconpy/_util.py
@@ -163,6 +163,8 @@ def service_request(caller: object = None, **kwargs) -> object:  # May return di
                         caller.headers['Authorization'] = f"Bearer {auth_response['body']['access_token']}"
                     else:
                         caller.headers['Authorization'] = "Bearer "
+                else:
+                    caller.headers['Authorization'] = f"Bearer {caller.auth_object.token_value}"
         except AttributeError:
             pass
 


### PR DESCRIPTION
## Propagate auth object
Relates to #829. I had the same issue and applied this fix.

- [ ] Enhancement
- [ ] Major Feature update
- [x] Bug fixes 
- [ ] Breaking Change
- [ ] Updated unit tests
- [ ] Documentation
- [ ] Code sample


