### PR TITLE
Add new sample: Hosts Pruner

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -40,7 +40,7 @@ The following samples are categorized by CrowdStrike Falcon API service collecti
 | [Falcon Flight Control](#falcon-flight-control) | [Find child CID](#find-child-cid)<BR/>[Host Group Duplicator](#host-group-duplicator)<BR/>[Execute a command on hosts across multiple children](#execute-a-command-on-hosts-across-multiple-children) |
 | [Falcon Intelligence](#falcon-intelligence) | [Manage sandbox uploads](#manage-sandbox-uploads)<BR/>[Falcon Intelligence sandbox scan](#falcon-intelligence-sandbox-scan)<BR/>[Get all artifacts](#get-all-artifacts)<BR/>[Quick Scan a target](#quick-scan-a-target)<BR/>[S3 Bucket Protection](#s3-bucket-protection) |
 | [Firewall Management](#firewall-management) | [Export Firewall events to a file](#export-firewall-events-to-a-file) |
-| [Hosts](#hosts) | [List sensors by hostname](#list-sensors-by-hostname)<BR/>[Manage duplicate sensors](#manage-duplicate-sensors)<BR/>[CUSSED (Manage stale sensors)](#cussed-manage-stale-sensors)<BR/>[Match usernames to hosts](#match-usernames-to-hosts)<BR/>[Offset vs. Token](#offset-vs-token)<BR/>[Quarantine a host](#quarantine-a-host)<BR/>[Quarantine a host (updated version)](#quarantine-a-host-updated-version) |
+| [Hosts](#hosts) | [List sensors by hostname](#list-sensors-by-hostname)<BR/>[Manage duplicate sensors](#manage-duplicate-sensors)<BR/>[CUSSED (Manage stale sensors)](#cussed-manage-stale-sensors)<BR/>[Match usernames to hosts](#match-usernames-to-hosts)<BR/>[Offset vs. Token](#offset-vs-token)<BR/>[Prune Hosts by Hostname or AID](#prune-hosts-by-hostname-or-aid)<BR/>[Quarantine a host](#quarantine-a-host)<BR/>[Quarantine a host (updated version)](#quarantine-a-host-updated-version) |
 | [Incidents](#incidents) | [CrowdScore QuickChart](#crowdscore-quickchart)<BR/>[Incident Triage](#incident-triage) |
 | [Intel](#intel) | [MISP Import](#misp-import) |
 | [IOC](#ioc) | [Create indicators](#create-indicators) |
@@ -484,6 +484,22 @@ This sample demonstrates the following CrowdStrike Hosts API operations:
 | Operation | Description |
 | :--- | :--- |
 | [QueryDevicesByFilter](https://falconpy.io/Service-Collections/Hosts.html#querydevicesbyfilter) | Search for hosts in your environment by platform, hostname, IP, and other criteria. |
+| [QueryDevicesByFilterScroll](https://falconpy.io/Service-Collections/Hosts.html#querydevicesbyfilterscroll) | Search for hosts in your environment by platform, hostname, IP, and other criteria with continuous pagination capability (based on offset pointer which expires after 2 minutes with no maximum limit). |
+
+---
+
+### Prune Hosts by Hostname or AID
+This sample demonstrates [removing and restoring hosts by hostname or AID](hosts/prune_hosts.py).
+
+[![Hosts](https://img.shields.io/badge/Service%20Class-Hosts_Pruner-silver?style=for-the-badge&labelColor=red&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAYAAAAi2ky3AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpaIVBzuIOGSoDmJBVEQ3rUIRKoRaoVUHk5f+CE0akhQXR8G14ODPYtXBxVlXB1dBEPwBcXNzUnSREu9LCi1ifPB4H+e9c7jvXkColZhmtY0Cmm6bqURczGRXxNAruhAEMI1hmVnGrCQl4bu+7hHg512MZ/m/+3N1qzmLAQGReIYZpk28Tjy5aRuc94kjrCirxOfEIyYVSPzIdcXjN84FlwWeGTHTqTniCLFYaGGlhVnR1IgniKOqplO+kPFY5bzFWStVWKNO/sNwTl9e4jrtASSwgEVIEKGggg2UYCNGp06KhRTdx338/a5fIpdCrg0wcsyjDA2y6wefwe/eWvnxMS8pHAfaXxznYxAI7QL1quN8HztO/QQIPgNXetNfrgFTn6RXm1r0COjZBi6um5qyB1zuAH1PhmzKrsTnL+TzwPsZjSkL9N4Cnate3xr3OH0A0tSr5A1wcAgMFSh7zeffHa19+/dNo38/hq9yr+iELI0AAAAGYktHRAAAAAAAAPlDu38AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQflDAsTByz7Va2cAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAYBJREFUKM+lkjFIlVEYht/zn3sFkYYUyUnIRcemhCtCU6JQOLiIU+QeJEQg6BBIm0s4RBCBLjq5OEvgJC1uOniJhivesLx17/97/vO9b4NK4g25157hfHCGB773/cA0HZIEAKiMj+LWiOxljG/i96pnCFP58XHnrWX2+9cj0dYl9Yu2FE9/9rXrcAAgs2eSyiBfOe/XRD503h/CuffOubQVUXL+Jh9BllzBbyJJBgDclVkO4Kukd8zzkXJbeUljIldFTstsmSHM6S81ma2KfPKlFdkGAMY4wzx/bbXapMy21My+YizdKNq5mDzLkrxafSxySFKjSWX2oTmjKzz4vN0r2lOFcL/Q3V0/mX95ILMXTTGYVfaut/aP2+oCMAvnZgCcsF5fcR0dg65YHAdwB+QApADvu0AuOe/ftlJAD7Nsgmm6yBjDtfWORJZlNtFyo/lR5Z7MyheKA5ktSur7sTAHazSG27pehjAiaVfkN8b4XFIJ/wOzbOx07VNRUuHy7w98CzCcGPyWywAAAABJRU5ErkJggg==)](https://github.com/CrowdStrike/falconpy/tree/main/samples/hosts#prune-hosts-by-hostname-or-aid) 
+
+#### Hosts API operations discussed
+This sample demonstrates the following CrowdStrike Hosts API operations:
+
+| Operation | Description |
+| :--- | :--- |
+| [PerformActionV2](https://falconpy.io/Service-Collections/Hosts.html#performactionv2) | Take various actions on the hosts in your environment. Contain or lift containment on a host. Delete or restore a host. |
+| [GetDeviceDetails](https://falconpy.io/Service-Collections/Hosts.html#getdevicedetails) | Get details on one or more hosts by providing agent IDs (AID). You can get a host's agent IDs (AIDs) from the [QueryDevicesByFilter](https://www.falconpy.io/Service-Collections/Hosts.html#querydevicesbyfilter) operation, the Falcon console or the Streaming API. |
 | [QueryDevicesByFilterScroll](https://falconpy.io/Service-Collections/Hosts.html#querydevicesbyfilterscroll) | Search for hosts in your environment by platform, hostname, IP, and other criteria with continuous pagination capability (based on offset pointer which expires after 2 minutes with no maximum limit). |
 
 ---

--- a/samples/hosts/README.md
+++ b/samples/hosts/README.md
@@ -9,6 +9,7 @@ The examples in this folder focus on leveraging CrowdStrike's Hosts API to perfo
 - [List (and optionally remove) stale sensors](#list-stale-sensors)
 - [Match usernames to Hosts](#match-usernames-to-hosts)
 - [Offset vs. Offset Tokens](#comparing-querydevicesbyfilter-and-querydevicesbyfilterscroll-offset-vs-token)
+- [Prune Hosts by Hostname or AID](#prune-hosts-by-hostname-or-aid)
 
 ## List sensors by hostname
 Loops through all hosts and displays the hostname and sensor version.
@@ -384,3 +385,107 @@ python3 offset_vs_token.py
 
 ### Example source code
 The source code for this example can be found [here](offset_vs_token.py).
+
+---
+
+## Prune Hosts by Hostname or AID
+Search for and optionally remove hosts by hostname or AID. Removed host AIDs are saved to a file which can be leveraged to restore removed hosts.
+
+### Running the program.
+In order to run this demonstration, you will need access to CrowdStrike API keys with the following scopes:
+
+| Service Collection | Scope |
+| :---- | :---- |
+| Hosts | __READ__, __WRITE__ |
+
+### Execution syntax
+
+List hosts by hostname or AID.
+
+```shell
+python3 prune_hosts.py -k $FALCON_CLIENT_ID -s $FALCON_CLIENT_SECRET -f HOSTNAME
+```
+
+Remove identified hosts.
+
+```shell
+python3 prune_hosts.py -k $FALCON_CLIENT_ID -s $FALCON_CLIENT_SECRET -f HOSTNAME -d
+```
+
+Restore previously deleted hosts from the restore file.
+
+```shell
+python3 prune_hosts.py -k $FALCON_CLIENT_ID -s $FALCON_CLIENT_SECRET -r -a RESTORE_FILENAME
+```
+
+Restore previously deleted hosts by AID.
+
+```shell
+python3 prune_hosts.py -k $FALCON_CLIENT_ID -s $FALCON_CLIENT_SECRET -r -a AID1,AID2,AID3
+```
+
+Change your BASE_URL to point to GovCloud.
+
+```shell
+python3 prune_hosts.py -k $FALCON_CLIENT_ID -s $FALCON_CLIENT_SECRET -b usgov1
+```
+
+Search a child tenant for hosts to remove.
+
+```shell
+python3 prune_hosts.py -k $FALCON_CLIENT_ID -s $FALCON_CLIENT_SECRET -f HOSTNAME -m CHILD_CID
+```
+
+### Command-line help
+Command-line help is available via the `-h` argument.
+
+```shell
+python3 prune_hosts.py -h
+usage: prune_hosts.py [-h] [-b BASE_URL] [-f FIND] [-r] [-a AIDS] [-d] [-m MSSP] -k FALCON_CLIENT_ID -s FALCON_CLIENT_SECRET
+
+Remove sensors by name or AID sample.
+
+ _______                        __ _______ __        __ __
+|   _   .----.-----.--.--.--.--|  |   _   |  |_.----|__|  |--.-----.
+|.  1___|   _|  _  |  |  |  |  _  |   1___|   _|   _|  |    <|  -__|
+|.  |___|__| |_____|________|_____|____   |____|__| |__|__|__|_____|
+|:  1   |                         |:  1   |
+|::.. . |                         |::.. . |        FalconPy v1.2
+`-------'                         `-------'
+
+ __ __   ___    _____ ______      ____  ____   __ __  ____     ___  ____
+|  T  T /   \  / ___/|      T    |    \|    \ |  T  T|    \   /  _]|    \
+|  l  |Y     Y(   \_ |      |    |  o  )  D  )|  |  ||  _  Y /  [_ |  D  )
+|  _  ||  O  | \__  Tl_j  l_j    |   _/|    / |  |  ||  |  |Y    _]|    /
+|  |  ||     | /  \ |  |  |      |  |  |    \ |  :  ||  |  ||   [_ |    \
+|  |  |l     ! \    |  |  |      |  |  |  .  Yl     ||  |  ||     T|  .  Y
+l__j__j \___/   \___j  l__j      l__j  l__j\_j \__,_jl__j__jl_____jl__j\_j
+
+Removes hosts by hostname or AID. Can restore hosts that have been removed.
+
+02.11.23 - jshcodes@CrowdStrike
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -b BASE_URL, --base_url BASE_URL
+                        CrowdStrike Region (us1, us2, eu1, usgov1)
+                        Only required for GovCloud users.
+  -f FIND, --find FIND  Hostname or AID string to use to identify hosts for removal.
+                        Hostname searches are stemmed, AID searches must be an exact match.
+  -r, --restore         Restores prevously deleted hosts using a save file or list of AIDs.
+                        Specify the AID list or filename using the `-a` command line argument.
+  -a AIDS, --aids AIDS  List of AIDs to restore (comma delimited string or a filename).
+  -d, --delete          Perform the delete, default behavior is to list only.
+  -m MSSP, --mssp MSSP  CID of a child tenant to access (MSSP only).
+
+required arguments:
+  -k FALCON_CLIENT_ID, --falcon_client_id FALCON_CLIENT_ID
+                        CrowdStrike Falcon API client ID.
+  -s FALCON_CLIENT_SECRET, --falcon_client_secret FALCON_CLIENT_SECRET
+                        CrowdStrike Falcon API client secret.
+```
+
+### Example source code
+The source code for this example can be found [here](prune_hosts.py).
+
+---

--- a/samples/hosts/prune_hosts.py
+++ b/samples/hosts/prune_hosts.py
@@ -1,0 +1,208 @@
+r"""Remove sensors by name or AID sample.
+
+ _______                        __ _______ __        __ __
+|   _   .----.-----.--.--.--.--|  |   _   |  |_.----|__|  |--.-----.
+|.  1___|   _|  _  |  |  |  |  _  |   1___|   _|   _|  |    <|  -__|
+|.  |___|__| |_____|________|_____|____   |____|__| |__|__|__|_____|
+|:  1   |                         |:  1   |
+|::.. . |                         |::.. . |        FalconPy v1.2
+`-------'                         `-------'
+
+ __ __   ___    _____ ______      ____  ____   __ __  ____     ___  ____
+|  T  T /   \  / ___/|      T    |    \|    \ |  T  T|    \   /  _]|    \
+|  l  |Y     Y(   \_ |      |    |  o  )  D  )|  |  ||  _  Y /  [_ |  D  )
+|  _  ||  O  | \__  Tl_j  l_j    |   _/|    / |  |  ||  |  |Y    _]|    /
+|  |  ||     | /  \ |  |  |      |  |  |    \ |  :  ||  |  ||   [_ |    \
+|  |  |l     ! \    |  |  |      |  |  |  .  Yl     ||  |  ||     T|  .  Y
+l__j__j \___/   \___j  l__j      l__j  l__j\_j \__,_jl__j__jl_____jl__j\_j
+
+Removes hosts by hostname or AID. Can restore hosts that have been removed.
+
+02.11.23 - jshcodes@CrowdStrike
+"""
+from argparse import ArgumentParser, RawTextHelpFormatter
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from os.path import exists
+from tabulate import tabulate
+from falconpy import Hosts
+
+
+MAX_RECORDS_PER_CALL = 5000
+TABLE_HEADERS = {
+    "device_id": "ID",
+    "hostname": "Hostname",
+    "platform_name": "Platform",
+    "os_version": "Version",
+    "last_seen": "Last Seen"
+}
+
+
+def consume_arguments():
+    """Consume any provided command line arguments."""
+    parser = ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
+    parser.add_argument("-b", "--base_url",
+                        help="CrowdStrike Region (us1, us2, eu1, usgov1)\n"
+                        "Only required for GovCloud users.",
+                        required=False,
+                        default="auto"
+                        )
+    parser.add_argument("-f", "--find",
+                        help="Hostname or AID string to use to identify hosts for removal.\n"
+                        "Hostname searches are stemmed, AID searches must be an exact match.",
+                        required=False,
+                        default=None
+                        )
+    parser.add_argument("-r", "--restore",
+                        help="Restores prevously deleted hosts using a save file or list of AIDs.\n"
+                        "Specify the AID list or filename using the `-a` command line argument.",
+                        required=False,
+                        action="store_true",
+                        default=False
+                        )
+    parser.add_argument("-a", "--aids",
+                        help="List of AIDs to restore (comma delimited string or a filename).",
+                        required=False
+                        )
+    parser.add_argument("-d", "--delete",
+                        help="Perform the delete, default behavior is to list only.",
+                        required=False,
+                        action="store_true",
+                        default=False
+                        )
+    parser.add_argument("-m", "--mssp",
+                        help="CID of a child tenant to access (MSSP only).",
+                        required=False,
+                        default=None
+                        )
+    requir = parser.add_argument_group("required arguments")
+    requir.add_argument("-k", "--falcon_client_id",
+                        help="CrowdStrike Falcon API client ID.",
+                        required=True
+                        )
+    requir.add_argument("-s", "--falcon_client_secret",
+                        help="CrowdStrike Falcon API client secret.",
+                        required=True
+                        )
+
+    return parser.parse_args()
+
+
+def hide_hosts(host_list: list, sdk: Hosts):
+    """Hide the hosts provided in the host list."""
+    def do_delete(id_list):
+        """Perform threaded host delete."""
+        res = sdk.perform_action(action_name="hide_host", ids=id_list)
+        if res["status_code"] == 202:
+            print(f"{len(id_list)} hosts removed successfully.")
+        else:
+            errs = []
+            for err in res["body"]["errors"]:
+                errs.append(f"[{err['code']}] {err['message']}")
+            print("\n".join(errs))
+
+    tstamp = str(int(datetime.now().timestamp()))
+    with open(f"{tstamp}.dlt", "w", encoding="utf-8") as save_file:
+        for aid in host_list:
+            save_file.write(f"{aid}\n")
+    # Only 100 hosts can be removed at a time
+    batches = [host_list[i:i+100] for i in range(0, len(host_list), 100)]
+    with ThreadPoolExecutor() as executor:
+        executor.map(do_delete, batches)
+    print(f"List of removed hosts saved to '{tstamp}.dlt'.")
+
+
+def unhide_hosts(host_list: list, sdk: Hosts):
+    """Restore the hosts provided in the host list."""
+    def do_restore(id_list):
+        """Perform threaded host restore."""
+        res = sdk.perform_action(action_name="unhide_host", ids=id_list)
+        if res["status_code"] == 202:
+            print(f"{len(id_list)} hosts restored successfully.")
+        else:
+            errs = []
+            for err in res["body"]["errors"]:
+                errs.append(f"[{err['code']}] {err['message']}")
+            print("\n".join(errs))
+    # Only 100 hosts can be restored at a time
+    batches = [host_list[i:i+100] for i in range(0, len(host_list), 100)]
+    with ThreadPoolExecutor() as executor:
+        executor.map(do_restore, batches)
+
+
+def get_host_list(sdk: Hosts, hostname, max_limit):
+    """Get a list of all hosts."""
+    all_host_ids = []
+    hosts_found = []
+    running = True
+    offset = None
+    filter_string = f"hostname:*'*{hostname}*',device_id:'{hostname}'"
+    while running:
+        host_lookup = sdk.query_devices_by_filter_scroll(limit=max_limit,
+                                                         offset=offset,
+                                                         sort="last_seen.desc",
+                                                         filter=filter_string
+                                                         )
+        if host_lookup["status_code"] != 200:
+            raise SystemExit("Unable to retrieve list of hosts from the CrowdStrike API.")
+        if host_lookup["body"]["resources"]:
+            all_host_ids.extend(host_lookup["body"]["resources"])
+            details = sdk.get_device_details(host_lookup["body"]["resources"])["body"]["resources"]
+            for host in details:
+                result = {
+                    "device_id": host["device_id"],
+                    "hostname": host.get("hostname", "Not found"),
+                    "platform_name": host.get("platform_name", "Not found"),
+                    "os_version": host.get("os_version", "Not found"),
+                    "last_seen": host["last_seen"]
+                }
+                hosts_found.append(result)
+
+        offset = host_lookup["body"]["meta"]["pagination"]["offset"]
+        if host_lookup["body"]["meta"]["pagination"]["total"] <= len(all_host_ids):
+            running = False
+
+    return hosts_found, all_host_ids
+
+
+if __name__ == "__main__":
+    cmd_line = consume_arguments()
+    # Connect to the CrowdStrike API Hosts service collection
+    hosts = Hosts(client_id=cmd_line.falcon_client_id,
+                  client_secret=cmd_line.falcon_client_secret,
+                  base_url=cmd_line.base_url,
+                  member_cid=cmd_line.mssp
+                  )
+    # Restore hosts
+    if cmd_line.restore:
+        if exists(cmd_line.aids):
+            print(f"Restoring hosts from {cmd_line.aids}.")
+            with open(cmd_line.aids, "r", encoding="utf-8") as load_file:
+                restores = [line.rstrip() for line in load_file]
+                unhide_hosts(restores, hosts)
+        else:
+            unhide_hosts(cmd_line.aids.split(","), hosts)
+        # Return a list of all identified hosts after performing a restore
+        cmd_line.find = "*"
+    # No action specified
+    if not cmd_line.find and not cmd_line.restore:
+        raise SystemExit(
+            "Specify a hostname or AID string using the `-f` argument in order to remove hosts."
+            )
+    # Retrieve all hosts matching our search
+    found, host_ids = get_host_list(hosts, cmd_line.find, MAX_RECORDS_PER_CALL)
+    # Display the results
+    if not found:
+        raise SystemExit("\nNo hosts identified.")
+    print(tabulate(tabular_data=found, headers=TABLE_HEADERS))
+    # Remove hosts
+    if not cmd_line.restore:
+        if cmd_line.delete:
+            if cmd_line.find.strip() == "*":
+                raise SystemExit("\nUnacceptable search string provided for delete processing.")
+            print(f"\nRemoving {len(found)} hosts.")
+            hide_hosts(host_ids, hosts)
+        else:
+            print(f"\n{len(found)} hosts identified.")
+            if cmd_line.find.strip() != "*":
+                print("No action performed. Pass `-d` on the command line to remove these hosts.")


### PR DESCRIPTION
# Hosts Pruner
This update provides a new sample, Hosts Pruner, which can prune and restore hosts from your tenant by Hostname or AID.

- [x] Documentation
- [x] Code sample

#### Unit test coverage
```shell
NOT REQUIRED FOR SAMPLE SUBMISSIONS
```

#### Bandit analysis
```shell
[main]	INFO	running on Python 3.9.16

Run started:2023-02-11 17:40:02.148270

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 179
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```
## Added features and functionality
+ Added: Hosts Pruner sample.
    - `samples/hosts/prune_hosts.py`
