### PR TITLE
Add Get MITRE ATT&CK reports sample

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,7 +28,9 @@ code samples:
 - samples/firewall_management/*.py
 - samples/flight_control/*.py
 - samples/hosts/*.py
+- samples/identity/*.py
 - samples/incidents/*.py
+- samples/intel/*.py
 - samples/ioc/*.py
 - samples/malquery/*.py
 - samples/prevention_policy/*.py

--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -796,3 +796,9 @@ GraphQL
 graphql
 primaryDisplayName
 secondaryDisplayName
+ATT
+GetMitreReport
+MITRE
+Mitre
+QueryMitreAttacks
+Chollima

--- a/samples/README.md
+++ b/samples/README.md
@@ -608,6 +608,22 @@ This sample demonstrates the following CrowdStrike Incidents API operations:
 ## Intel
 This category provides samples that demonstrate the CrowdStrike Falcon Intel API service collection.
 
+### Get MITRE ATT&CK Reports
+Retrieve some or all available adversary MITRE ATT&CK reports.
+
+[![Intel](https://img.shields.io/badge/Service%20Class-Get_MITRE_ATT&CK_Reports-silver?style=for-the-badge&labelColor=red&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAYAAAAi2ky3AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpaIVBzuIOGSoDmJBVEQ3rUIRKoRaoVUHk5f+CE0akhQXR8G14ODPYtXBxVlXB1dBEPwBcXNzUnSREu9LCi1ifPB4H+e9c7jvXkColZhmtY0Cmm6bqURczGRXxNAruhAEMI1hmVnGrCQl4bu+7hHg512MZ/m/+3N1qzmLAQGReIYZpk28Tjy5aRuc94kjrCirxOfEIyYVSPzIdcXjN84FlwWeGTHTqTniCLFYaGGlhVnR1IgniKOqplO+kPFY5bzFWStVWKNO/sNwTl9e4jrtASSwgEVIEKGggg2UYCNGp06KhRTdx338/a5fIpdCrg0wcsyjDA2y6wefwe/eWvnxMS8pHAfaXxznYxAI7QL1quN8HztO/QQIPgNXetNfrgFTn6RXm1r0COjZBi6um5qyB1zuAH1PhmzKrsTnL+TzwPsZjSkL9N4Cnate3xr3OH0A0tSr5A1wcAgMFSh7zeffHa19+/dNo38/hq9yr+iELI0AAAAGYktHRAAAAAAAAPlDu38AAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQflDAsTByz7Va2cAAAAGXRFWHRDb21tZW50AENyZWF0ZWQgd2l0aCBHSU1QV4EOFwAAAYBJREFUKM+lkjFIlVEYht/zn3sFkYYUyUnIRcemhCtCU6JQOLiIU+QeJEQg6BBIm0s4RBCBLjq5OEvgJC1uOniJhivesLx17/97/vO9b4NK4g25157hfHCGB773/cA0HZIEAKiMj+LWiOxljG/i96pnCFP58XHnrWX2+9cj0dYl9Yu2FE9/9rXrcAAgs2eSyiBfOe/XRD503h/CuffOubQVUXL+Jh9BllzBbyJJBgDclVkO4Kukd8zzkXJbeUljIldFTstsmSHM6S81ma2KfPKlFdkGAMY4wzx/bbXapMy21My+YizdKNq5mDzLkrxafSxySFKjSWX2oTmjKzz4vN0r2lOFcL/Q3V0/mX95ILMXTTGYVfaut/aP2+oCMAvnZgCcsF5fcR0dg65YHAdwB+QApADvu0AuOe/ftlJAD7Nsgmm6yBjDtfWORJZlNtFyo/lR5Z7MyheKA5ktSur7sTAHazSG27pehjAiaVfkN8b4XFIJ/wOzbOx07VNRUuHy7w98CzCcGPyWywAAAABJRU5ErkJggg==)](https://github.com/CrowdStrike/falconpy/tree/main/samples/intel#get-mitre-attck-reports)
+
+#### Intel API operations discussed
+This sample demonstrates the following CrowdStrike Intel API operations:
+
+| Operation | Description |
+| :--- | :--- |
+| [GetIntelActorEntities](https://falconpy.io/Service-Collections/Intel.html#getintelactorentities) | Retrieve specific actors using their actor IDs. |
+| [GetMitreReport](https://www.falconpy.io/Service-Collections/Intel.html#getmitrereport) | Export Mitre ATT&CK information for a given actor. |
+| [QueryMitreAttacks](https://www.falconpy.io/Service-Collections/Intel.html#querymitreattacks) | Gets MITRE tactics and techniques for the given actor. |
+
+---
+
 ### MISP Import
 This [utility](https://github.com/CrowdStrike/MISP-tools#manual-import) will import CrowdStrike Intel Threat indicators (Actors, Indicators and Reports) into your instance of [MISP](https://github.com/MISP/MISP).
 

--- a/samples/identity/README.md
+++ b/samples/identity/README.md
@@ -14,7 +14,7 @@ In order to run this demonstration, you you will need access to CrowdStrike API 
 
 | Service Collection | Scope |
 | :---- | :---- |
-| IdentityProtection | __READ__ |
+| Identity Protection | __READ__ |
 
 ### Execution syntax
 This sample leverages simple command-line arguments to implement functionality.

--- a/samples/intel/README.md
+++ b/samples/intel/README.md
@@ -1,0 +1,97 @@
+![CrowdStrike Falcon](https://raw.githubusercontent.com/CrowdStrike/falconpy/main/docs/asset/cs-logo.png)
+![Twitter URL](https://img.shields.io/twitter/url?label=Follow%20%40CrowdStrike&style=social&url=https%3A%2F%2Ftwitter.com%2FCrowdStrike)
+
+# Intel examples
+The examples within this folder focus on leveraging CrowdStrike Falcon Intel service collection.
+
+- [Get MITRE ATT&CK reports](#get-mitre-attck-reports)
+
+## Get MITRE ATT&CK Reports
+Retrieves MITRE ATT&CK reports for specified adversaries.
+
+### Running the program
+In order to run this demonstration, you you will need access to CrowdStrike API keys with the following scopes:
+
+| Service Collection | Scope |
+| :---- | :---- |
+| Intel | __READ__ |
+
+### Execution syntax
+This sample leverages simple command-line arguments to implement functionality.
+
+#### Basic usage
+Retrieve all available MITRE ATT&CK reports.
+
+```shell
+python3 get_mitre_reports.py -k $FALCON_CLIENT_ID -s $FALCON_CLIENT_SECRET
+```
+
+> Execute the routine for GovCloud customers.
+
+```shell
+python3 get_mitre_reports.py -k $FALCON_CLIENT_ID -s $FALCON_CLIENT_SECRET -g
+```
+
+> Only retrieve available kitten reports.
+
+```shell
+python3 get_mitre_reports.py -k $FALCON_CLIENT_ID -s $FALCON_CLIENT_SECRET -i kitten
+```
+
+> Retrieve all available reports for bears, jackals, spiders and also grab Stardust Chollima.
+
+```shell
+python3 get_mitre_reports.py -k $FALCON_CLIENT_ID -s $FALCON_CLIENT_SECRET -i bear,jackal,spider,stardust
+```
+
+#### Command-line help
+Command-line help is available via the `-h` argument.
+
+```shell
+python3 get_mitre_reports.py -h
+usage: get_mitre_reports.py [-h] -k FALCON_CLIENT_ID -s FALCON_CLIENT_SECRET [-g] [-f FORMAT] [-i ID_SEARCH]
+
+Retrieve MITRE reports for adversaries.
+
+ _______                        __ _______ __        __ __
+|   _   .----.-----.--.--.--.--|  |   _   |  |_.----|__|  |--.-----.
+|.  1___|   _|  _  |  |  |  |  _  |   1___|   _|   _|  |    <|  -__|
+|.  |___|__| |_____|________|_____|____   |____|__| |__|__|__|_____|
+|:  1   |                         |:  1   |
+|::.. . |                         |::.. . |       FalconPy v1.2.10
+`-------'                         `-------'
+
+ _   _  _  ___  ___ ___      _  ___  ___ _    __  _  _
+| \_/ || ||_ _|| o \ __|    / \|_ _||_ _(o)  / _|| |//
+| \_/ || | | | |   / _|    | o || |  | |/oV7( (_ |  (
+|_| |_||_| |_| |_|\\___|   |_n_||_|  |_|\_n\ \__||_|\\
+
+____ ____ ___  ____ ____ ___   ___  ____ _ _ _ _  _ _    ____ ____ ___
+|__/ |___ |__] |  | |__/  |    |  \ |  | | | | |\ | |    |  | |__| |  \
+|  \ |___ |    |__| |  \  |    |__/ |__| |_|_| | \| |___ |__| |  | |__/
+
+Download MITRE ATT&CK reports for specified (or all) adversaries.
+
+This application requires:
+    colorama
+    crowdstrike-falconpy v1.2.10+
+
+Created: 02.24.23 - jshcodes@CrowdStrike
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -g, --usgov           US GovCloud customers
+  -f FORMAT, --format FORMAT
+                        Report format (csv [default] or json)
+  -i ID_SEARCH, --id_search ID_SEARCH
+                        Filter by actor slug (stemmed search, comma delimit)
+
+required arguments:
+  -k FALCON_CLIENT_ID, --falcon_client_id FALCON_CLIENT_ID
+                        CrowdStrike Falcon API Client ID
+  -s FALCON_CLIENT_SECRET, --falcon_client_secret FALCON_CLIENT_SECRET
+                        CrowdStrike Falcon API Client Secret
+```
+
+### Example source code
+The source code for this example can be found [here](get_mitre_reports.py).

--- a/samples/intel/get_mitre_reports.py
+++ b/samples/intel/get_mitre_reports.py
@@ -1,0 +1,168 @@
+r"""Retrieve MITRE reports for adversaries.
+
+ _______                        __ _______ __        __ __
+|   _   .----.-----.--.--.--.--|  |   _   |  |_.----|__|  |--.-----.
+|.  1___|   _|  _  |  |  |  |  _  |   1___|   _|   _|  |    <|  -__|
+|.  |___|__| |_____|________|_____|____   |____|__| |__|__|__|_____|
+|:  1   |                         |:  1   |
+|::.. . |                         |::.. . |       FalconPy v1.2.10
+`-------'                         `-------'
+
+ _   _  _  ___  ___ ___      _  ___  ___ _    __  _  _
+| \_/ || ||_ _|| o \ __|    / \|_ _||_ _(o)  / _|| |//
+| \_/ || | | | |   / _|    | o || |  | |/oV7( (_ |  (
+|_| |_||_| |_| |_|\\___|   |_n_||_|  |_|\_n\ \__||_|\\
+
+____ ____ ___  ____ ____ ___   ___  ____ _ _ _ _  _ _    ____ ____ ___
+|__/ |___ |__] |  | |__/  |    |  \ |  | | | | |\ | |    |  | |__| |  \
+|  \ |___ |    |__| |  \  |    |__/ |__| |_|_| | \| |___ |__| |  | |__/
+
+Download MITRE ATT&CK reports for specified (or all) adversaries.
+
+This application requires:
+    colorama
+    crowdstrike-falconpy v1.2.10+
+
+Created: 02.24.23 - jshcodes@CrowdStrike
+"""
+import os
+from argparse import ArgumentParser, RawTextHelpFormatter, Namespace
+from datetime import datetime
+from concurrent.futures import ThreadPoolExecutor
+from random import randrange  # non-cryptographic usage
+try:
+    from colorama import Fore, Style
+except ImportError as no_colorama:
+    raise SystemExit(
+        "This application requires the colorama package.\n"
+        "Install: python3 -m pip install colorama"
+        ) from no_colorama
+try:
+    from falconpy import Intel, _VERSION
+except ImportError as no_falconpy:
+    raise SystemExit(
+        "This application requires the crowdstrike-falconpy (v1.2.10+) package.\n"
+        "Install: python3 -m pip install crowdstrike-falconpy"
+        ) from no_falconpy
+
+
+def shiny(message: str):
+    """Output fabulous terminal messages."""
+    colors = [
+        Fore.MAGENTA, Fore.CYAN, Fore.WHITE, Fore.LIGHTWHITE_EX, Fore.RED,
+        Fore.LIGHTYELLOW_EX, Fore.LIGHTBLUE_EX, Fore.LIGHTCYAN_EX, Fore.GREEN,
+        Fore.LIGHTGREEN_EX, Fore.LIGHTMAGENTA_EX, Fore.LIGHTRED_EX, Fore.YELLOW
+        ]
+    fantastic = [f"{colors[randrange(0, len(colors) - 1)]}{c}" for c in message]  # nosec B311
+    fantastic.append(Style.RESET_ALL)
+
+    return "".join(fantastic).ljust(120, " ")
+
+
+def version_check():
+    """Confirm the version of FalconPy we're running supports the syntax we're using."""
+    valid_version = False
+    vers = _VERSION.split(".")
+    major_minor = float(f"{vers[0]}.{vers[1]}")
+    if major_minor >= 1.2 and int(vers[2]) >= 10:
+        valid_version = True
+
+    if not valid_version:
+        raise SystemExit("This example requires crowdstrike-falconpy v1.2.10 or greater.")
+
+
+def download_thread(actor_id: str, sdk: Intel, file_format: str, folder: str):
+    """Download a MITRE report for the specified adversary."""
+    download_successful = False
+    actor_name = f"{actor_id.split('-')[0].title()} {actor_id.split('-')[1].title()}"
+    detail_available = sdk.query_mitre_attacks(id=actor_id)["body"]["resources"]
+    if detail_available:
+        filename = f"{actor_id.replace('-', '_')}.{file_format}"
+        print(f"  Retrieving {shiny(actor_name)}", end="\r", flush=True)
+        filename = os.path.join(folder, filename)
+        with open(filename, "wb") as save_file:
+            save_file.write(sdk.get_mitre_report(actor_id=actor_id, format=file_format))
+        download_successful = True
+
+    return download_successful
+
+
+def consume_arguments():
+    """Consume any provided command line arguments."""
+    parser = ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
+    required = parser.add_argument_group("required arguments")
+    required.add_argument("-k", "--falcon_client_id",
+                          help="CrowdStrike Falcon API Client ID",
+                          required=True
+                          )
+    required.add_argument("-s", "--falcon_client_secret",
+                          help="CrowdStrike Falcon API Client Secret",
+                          required=True
+                          )
+    parser.add_argument("-g", "--usgov",
+                        help="US GovCloud customers",
+                        default=False,
+                        action="store_true"
+                        )
+    parser.add_argument("-f", "--format",
+                        help="Report format (csv [default] or json)",
+                        default="csv"
+                        )
+    parser.add_argument("-i", "--id_search",
+                        help="Filter by actor slug (stemmed search, comma delimit)",
+                        default=None
+                        )
+
+    return parser.parse_args()
+
+
+def get_actor_slugs(sdk: Intel, id_string: str):
+    """Retrieve a list of actor slugs for the specified (or all) adversaries."""
+    filter_string = None
+    if id_string:
+        filters = []
+        for act in id_string.split(","):
+            filters.append(f"slug:*'*{act.lower()}*'")
+        filter_string = ",".join(filters)
+    actors = sdk.query_actor_entities(limit=5000, filter=filter_string, fields="slug")
+    if actors["status_code"] != 200:
+        error_detail = f"API Error: {actors['body']['errors'][0]['message']}"
+        raise SystemExit(error_detail)
+    return [a["slug"] for a in actors["body"]["resources"]]
+
+
+def open_sdk(cmd: Namespace):
+    """Return an authenticated instance of the Intel Service Class."""
+    return Intel(client_id=cmdline.falcon_client_id,
+                 client_secret=cmdline.falcon_client_secret,
+                 base_url="usgov1" if cmd.usgov else "auto"
+                 )
+
+
+def download_reports(sdk: Intel, file_format: str, actors: list):
+    """Asynchronously download all available reports for the adversary list."""
+    subfolder = os.path.join(os.getcwd(), f"mitre_{datetime.utcnow().strftime('%m%d%YT%H%M%SZ')}")
+    os.makedirs(subfolder, exist_ok=True)
+    success = 0
+    with ThreadPoolExecutor() as executor:
+        futures = {
+            executor.submit(download_thread, slug, sdk, file_format, subfolder) for slug in actors
+        }
+        for fut in futures:
+            if fut.result():
+                success += 1
+
+    print(f"{success} MITRE ATT&CK reports downloaded.")
+
+
+if __name__ == "__main__":
+    # Confirm our running FalconPy version
+    version_check()
+    # Retrieve provided command line arguments
+    cmdline = consume_arguments()
+    # Create an instance of the Intel Service Class
+    intel = open_sdk(cmdline)
+    # Get a list of available adversary slugs filtering by the id_search argument
+    slugs = get_actor_slugs(intel, cmdline.id_search)
+    # Download all reports to a subfolder using the specified file format
+    download_reports(intel, cmdline.format, slugs)


### PR DESCRIPTION
# Get MITRE Reports
This update provides a new sample, Get MITRE Reports, which will download MITRE ATT&CK reports for specified adversaries in `csv` or `json` format.  Downloaded reports are saved to a subfolder within the current working directory.

- [x] Documentation
- [x] Code sample

#### Unit test coverage
```shell
NOT REQUIRED FOR SAMPLE SUBMISSIONS
```

#### Bandit analysis
```shell
[main]	INFO	running on Python 3.9.16

Run started:2023-02-25 15:30:19.156629

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 136
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```
## Added features and functionality
+ Added: Get MITRE ATT&CK Reports sample
    - `samples/intel/get_mitre_reports.py`
    - `samples/intel/README.md`

## Other
+ Updated Samples home README.md to reflect new examples.

