### PR TITLE
Fixed dependency issue in create-lambda-layer.sh script

### DIFF
--- a/util/create-lambda-layer.sh
+++ b/util/create-lambda-layer.sh
@@ -7,11 +7,14 @@
 # Assumes the docker service is running.
 #
 # Currently targets Python 3.8
-echo "crowdstrike-falconpy" > lambda-requirements.txt
+cat - << EOF > lambda-requirements.txt
+crowdstrike-falconpy
+urllib3 < 2.0
+EOF
 # Remove any old copies
 rm falconpy-layer.zip >/dev/null 2>&1
 # Run the lambci image and install the requirements
-docker run --rm -v $(pwd):/foo -w /foo lambci/lambda:build-python3.8 \
+docker run --rm --entrypoint '' -v $(pwd):/foo -w /foo public.ecr.aws/lambda/python:3.8 \
 pip install -r lambda-requirements.txt -t python
 # Create the layer archive
 zip -r falconpy-layer.zip python


### PR DESCRIPTION
## Fixed dependency issue in create-lambda-layer.sh script
This updates the `create-lambda-layer.sh` script to isolate against the 2.x version of `urllib3` which requires that a newer version of OpenSSL be installed.

- [x] Bug fixes

#### Unit test coverage
_Eliding as no python code was modified_

#### Bandit analysis
_Eliding as no python code was modified_

## Issues resolved
* Fixes https://github.com/CrowdStrike/falconpy/issues/995 by pinning `urllib3 < 2.0`

## Other
* This also updates the Docker image used in building the layer to an officially-supported AWS image instead of LambCI images (which were archived earlier this year in favor of the official AWS images: https://github.com/lambci/docker-lambda)
