### PR TITLE
Update create-lambda-layer.sh

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -87,6 +87,7 @@ This has been a critical element in the development of the FalconPy project.
 + Chris, `@chrisbvt`
 + Alex, `@khyberspache`
 + Phil Massyn, `@massyn`
++ Russell Snyder, `@rusnyder`
 
 
 ## Sponsors

--- a/util/create-lambda-layer.sh
+++ b/util/create-lambda-layer.sh
@@ -7,11 +7,14 @@
 # Assumes the docker service is running.
 #
 # Currently targets Python 3.8
-echo "crowdstrike-falconpy" > lambda-requirements.txt
+cat - << EOF > lambda-requirements.txt
+crowdstrike-falconpy
+urllib3 < 2.0
+EOF
 # Remove any old copies
 rm falconpy-layer.zip >/dev/null 2>&1
 # Run the lambci image and install the requirements
-docker run --rm -v $(pwd):/foo -w /foo lambci/lambda:build-python3.8 \
+docker run --rm --entrypoint '' -v $(pwd):/foo -w /foo public.ecr.aws/lambda/python:3.8 \
 pip install -r lambda-requirements.txt -t python
 # Create the layer archive
 zip -r falconpy-layer.zip python


### PR DESCRIPTION
# Update create-lambda-layer.sh
This pull request addresses an issue within the `create-lambda-layer.sh` utility related to the version of the dependency `urllib3` and the running environment within AWS Lambda.

This pull request also updates the docker image to leverage the officially supported images provided by AWS.

> Thanks go out to @rusnyder for submitting these updates.

- [x] Bug fixes 
- [x] Code sample

#### Unit test coverage
```shell
Not required for utilities submissions. Python library code remains unchanged.
```

#### Bandit analysis
```shell
Not required for utilities submissions. Python library code remains unchanged.
```

## Issues resolved
+ Fixed: Addresses the `urllib3` dependency issue by pinning the version of `urllib3` to < `2.0`. Closes #995.
    - `util/create-lambda-layer.sh`

+ Updated: Moved docker image over to the AWS support solution.
    - `util/create-lambda-layer.sh`
