### PR TITLE
Updated get_hostnames function to ignore comments.

### DIFF
--- a/samples/hosts/host_search.py
+++ b/samples/hosts/host_search.py
@@ -22,6 +22,7 @@ list of hostnames to the list of hosts in the Falcon Console to determine
 which hostnames are not currently reporting in to the console.
 
 Developed by @Don-Swanson-Adobe
+Modification: 05.28.24 - David M. Berry - Updated get_hostnames function to ignore comments.
 """
 import os
 import logging
@@ -79,7 +80,7 @@ def get_hostnames(target_file: str):
     except FileNotFoundError:
         raise SystemExit(
             "You must provide a valid hostname file with the '-f' argument, "
-            "or a host with the '-h' argument in order to run this program."
+            "or a host with the '-n' argument in order to run this program."
             )
 
 

--- a/samples/hosts/host_search.py
+++ b/samples/hosts/host_search.py
@@ -66,12 +66,16 @@ def consume_arguments() -> Namespace:
 
 
 def get_hostnames(target_file: str):
-    """Open CSV and import serials."""
+    """Open file and import hostnames, ignoring comments."""
     try:
-        with open(target_file, newline='') as host_file:
+        with open(target_file, 'r') as host_file:
             print("Opening hostname file")
-            return host_file.read().splitlines()
-
+            hostnames = []
+            for line in host_file:
+                line = line.split('#')[0].strip()  # Remove comments and strip whitespace
+                if line:  # Ignore empty lines
+                    hostnames.append(line)
+            return hostnames
     except FileNotFoundError:
         raise SystemExit(
             "You must provide a valid hostname file with the '-f' argument, "


### PR DESCRIPTION
## host_search.py update

Updated get_hostnames function to ignore comments in hostname files.

- [x] Enhancement
- [x] Updated unit tests
- [x] Code sample


#### Unit test coverage
unit tests do not appear to currently cover samples


#### Bandit analysis
```shell
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: None
[main]	INFO	running on Python 3.11.7
Working... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:01
Run started:2024-05-28 17:32:34.545861

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 66789
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):

Formatting
--------------------------------------------------------
0

Code style and syntax
--------------------------------------------------------
pylint: Command line or configuration file:1: UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.BaseException' ?) instead.
pylint: Command line or configuration file:1: UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.Exception' ?) instead.

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

Docstring style and syntax
--------------------------------------------------------
```
## Added features and functionality
+ the get_hostnames function will now ignore comments and whitespace that exist in any text file passed via the command line.

## Issues resolved
+ Bug fix: 
* Fixes https://github.com/CrowdStrike/falconpy/issues/1168 by ignoring comments in the hostname_file

## Other
+ Documentation:

This is a relatively simple change to the get_hostnames function. By splitting a line from any comment (in case a comment is included after a valid hostname entry on the same line), and removing any whitespace, we can ensure the output.csv file does not contain any unintended results.


```shell
            hostnames = []
            for line in host_file:
                line = line.split('#')[0].strip()  # Remove comments and strip whitespace
                if line:  # Ignore empty lines
                    hostnames.append(line)
```


Updated code is here for reference: https://github.com/David-M-Berry/falconpy/blob/main/samples/hosts/host_search.py