### PR TITLE
Remove requests version pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@
 #
 #    pip-compile requirements.in
 #
-requests>=2.32.0          # via -r requirements.in
+requests		   # via -r requirements.in
 urllib3>=1.26.10           # via -r requirements.in, requests
 


### PR DESCRIPTION
# Update requirements.txt
This update removes the version pin for the `requests` library as this causes dependency issues depending on version of python used.

> [!IMPORTANT]
> FalconPy currently supports Python 3.7 - 3.12.

- [x] Documentation


#### Unit test coverage
```shell
NOT REQUIRED
```

#### Bandit analysis
```shell
[main]	INFO	running on Python 3.11.8
Working... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:02
Run started:2024-06-05 14:47:03.696359

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 69884
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```
