### PR TITLE
Pin a specific version of setuptools to prevent issues with the new release

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,4 +17,4 @@ pytest-cov>=2.11.1  # via -r requirements-dev.in
 pytest>=6.2.2       # via -r requirements-dev.in
 ipython>=8.10.0     # via -r requirements-dev.in, pinned by Snyk to avoid SNYK-PYTHON-IPYTHON-3318382
 pydocstyle>=6.1.0
-setuptools>=65.5.1  # not directly required, pinned by Snyk to avoid SNYK-PYTHON-SETUPTOOLS-3113904
+setuptools~=70.3.0  # pinning to avoid failures with new iterations of setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@
 #
 requests		   # via -r requirements.in
 urllib3                    # via -r requirements.in, requests
-
+setuptools~=70.3.0


### PR DESCRIPTION
# Pin a specific version of setuptools to prevent issues with the new release

We have had issues with using setuptools versions >70.3.0. Whenever we utilize those versions, we've noticed Azure driver failures on Databricks. Pinning this version of setuptools successfully corrected the issue, and prevents future failures by placing an upper bound on the version of setuptools being installed.

- [x] Bug fixes 

#### Unit test coverage
```shell
NOT REQUIRED FOR DEPENDENCY UPDATES
```

#### Bandit analysis
```shell
NOT REQUIRED FOR DEPENDENCY UPDATES
```

## Issues resolved
+ Bug fix: Pins the version of __setuptools__ to `v70.3.0`. This prevents a bug with Microsoft Azure driver failures coming from a yanked release of __setuptools__ (`v71.0.1`).
    - `requirements-dev.txt`
    - `requirements.txt`
