### PR TITLE
Pin setuptools in the setup files

### DIFF
--- a/dev_setup.py
+++ b/dev_setup.py
@@ -123,7 +123,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "requests",
-        "urllib3"
+        "urllib3",
+        "setuptools~=70.3.0"
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "requests",
-        "urllib3"
+        "urllib3",
+        "setuptools~=70.3.0"
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
This PR addresses the same issue as [my previous PR](https://github.com/CrowdStrike/falconpy/pull/1203) but at build.

## Pin setuptools in the setup files
- [x] Bug fixes 

#### Unit test coverage
```shell
NOT REQUIRED FOR DEPENDENCY UPDATES
```

#### Bandit analysis
```shell
NOT REQUIRED FOR DEPENDENCY UPDATES
```

## Issues resolved
+ Bug fix: Pins the version of __setuptools__ to `v70.3.0`. This prevents a bug with Microsoft Azure driver failures coming from a yanked release of __setuptools__ (`v71.0.1`).
    - `dev-setup.py`
    - `setup.py`
