### PR TITLE
Fix GUI image download location

### DIFF
--- a/samples/workflows/workflow_manager_gui.py
+++ b/samples/workflows/workflow_manager_gui.py
@@ -793,6 +793,6 @@ LOGIN_FAIL = r"""
 
 if __name__ == "__main__":
     gui_image("program_icon.png", "program_icon.png")
-    gui_image("csfalcon.png", "running_icon.png")
-    gui_image("cs-logo.png", "config_icon.png")
+    gui_image("running_icon.png", "running_icon.png")
+    gui_image("config_icon.png", "config_icon.png")
     main()


### PR DESCRIPTION
# Fix GUI image download location (Workflow Manager sample)
This is a minor fix for the GUI interface in the Workflow Manager sample.

- [x] Bug fixes 
- [x] Code sample

#### Unit test coverage
```shell
NOT REQUIRED FOR SAMPLE SUBMISSIONS
```

#### Bandit analysis
```shell
[main]	INFO	running on Python 3.13.0

Run started:2024-11-12 21:31:30.180880

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 17996
	Total lines skipped (#nosec): 2

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```

## Issues resolved
+ Bug fix: Fix download filename for GUI image downloads.
    - `samples/workflows/workflow_manager_gui.py`
