### PR TITLE
Add new os name variations to Sensor Download sample

### DIFF
--- a/samples/sensor_download/download_sensor.py
+++ b/samples/sensor_download/download_sensor.py
@@ -156,7 +156,7 @@ def create_constants():
     os_name = ""
     if args.os:
         check_os = args.os.lower()
-        if check_os in ["rhel", "centos", "oracle", "rhel/centos/oracle"]:
+        if check_os == "rhel/centos/oracle":
             os_name = "RHEL/CentOS/Oracle"
         if check_os in ["amzn", "az", "amazon", "amazon linux"]:
             os_name = "Amazon Linux"
@@ -172,6 +172,14 @@ def create_constants():
             os_name = "Container"
         if check_os in ["idp", "identity", "identity protection"]:
             os_name = "Identity*"
+        if check_os in ["rhel/centos stream/oracle", "stream", "centos stream"]:
+            os_name = "RHEL/CentOS Stream/Oracle"
+        if check_os in ["rhel/centos", "centos"]:
+            os_name = "RHEL/CentOS"
+        if check_os == "rhel":
+            os_name = "RHEL"
+        if check_os == "oracle":
+            os_name = "Oracle"
 
     os_filter = ""
     if os_name:
@@ -181,7 +189,8 @@ def create_constants():
             allowed = ["rhel", "centos", "oracle", "rhel/centos/oracle", "mac", "macos", "apple",
                        "amzn", "az", "amazon", "amazon linux", "ubuntu", "kali", "deb", "debian",
                        "sles", "suse", "win", "windows", "microsoft", "container", "docker",
-                       "kubernetes", "idp", "identity", "identity protection"
+                       "kubernetes", "idp", "identity", "identity protection", "stream",
+                       "rhel/centos stream/oracle", "rhel/centos"
                        ]
             raise SystemExit(f"Invalid operating system specified.\nAllowed values: {', '.join(allowed)}")
     return cmd, args.key, args.secret, os_filter, args.filename, args.table_format, args.all, \


### PR DESCRIPTION
# Sensor Download sample update
This pull request updates the available operating system types to the Sensor Download sample.

- [x] Enhancement
- [x] Code sample

#### Unit test coverage
```shell
NOT REQUIRED FOR SAMPLE SUBMISSIONS
```

#### Bandit analysis
```shell
[main]	INFO	running on Python 3.13.1
Run started:2025-02-05 15:17:45.812025

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 18080
	Total lines skipped (#nosec): 2

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```
## Added features and functionality
+ Added: New operating system variations added to the Sensor Download sample.
    - `samples/sensor_download/download_sensor.py`
