### PR TITLE
Updated logic on graphql_pagination.py to correctly validate falconpy version 

### DIFF
--- a/samples/identity/graphql_pagination.py
+++ b/samples/identity/graphql_pagination.py
@@ -50,7 +50,9 @@ def version_check():
     valid_version = False
     vers = _VERSION.split(".")
     major_minor = float(f"{vers[0]}.{vers[1]}")
-    if major_minor >= 1.2 and int(vers[2]) >= 11:
+    if major_minor > 1.2:
+        valid_version = True
+    elif major_minor == 1.2 and int(vers[2]) >= 11:
         valid_version = True
 
     if not valid_version:


### PR DESCRIPTION
## Updated logic on `graphql_pagination.py` to correctly validate falconpy version 
A simple change in logic so that a major version higher than 1.2 but a minor version lower than 11 will still be
considered a valid version and will not raise a `SystemExit`.

- [x] Bug fixes 


#### Unit test coverage
None at this time. See the "Other" section at the bottom of this PR.

#### Bandit analysis
None at this time. See the "Other" section at the bottom of this PR.

## Added features and functionality
* `graphql_pagination.py` now correctly validates major versions greater than 1.2 with a minor version lower than 11.

## Issues resolved
* Fixes https://github.com/CrowdStrike/falconpy/issues/1281 by checking the major version individually before checking the minor version. If the major version is greater than 1.2, we don't even need to consider the minor version and can halt further validation.


## Other
Due to lack of access to an API key for testing, I was unable to conduct the required unit testing and testing with bandit. I was told by one of the maintainers to go ahead with this PR. 

In lieu of the standard testing, and since this is relatively simple, I have done a little spot testing. Please note that this is a slightly modified version of the function that I changed in this PR, and **is not present in the code that was submitted**.

```python 
def version_check(version):
    """Confirm the version of FalconPy we're running supports the syntax we're using."""
    valid_version = False
    vers = version.split(".")
    major_minor = float(f"{vers[0]}.{vers[1]}")
    if major_minor > 1.2:
        valid_version = True
    elif major_minor == 1.2 and int(vers[2]) >= 11:
        valid_version = True

    if not valid_version:
        raise SystemExit("This example requires crowdstrike-falconpy v1.2.11 or greater.")
    
    return valid_version
    

if __name__ == "__main__":
    print(version_check("1.4.1"))   # True
    print(version_check("1.2.11"))  # True
    print(version_check("1.2.9"))   # This example requires crowdstrike-falconpy v1.2.11 or greater.
```

By slight modifying the `validate_version` function to take a string as an argument, and having it return the `valid_version` boolean, I was able to feed the function several strings that are structured like falconpy versions. 

The outputs from this modified function show that the new control flow logic is working as expected, as far as I can tell.

