### PR TITLE
Changed 'search_id' to 'id' in scrub_target method in _uber.py

### DIFF
--- a/src/falconpy/_util/_uber.py
+++ b/src/falconpy/_util/_uber.py
@@ -115,7 +115,7 @@ def scrub_target(oper: str, scrubbed: str, kwas: dict) -> str:
         "GetLookupFromPackageWithNamespaceV1": ["repository", "namespace", "package", "filename"],
         "GetLookupFromPackageV1": ["repository", "package", "filename"],
         "StartSearchV1": ["repository"],
-        "GetSearchStatusV1": ["repository", "search_id"],
+        "GetSearchStatusV1": ["repository", "id"],
         "StopSearchV1": ["repository", "id"]
     }
     for field_value, field_names in field_mapping.items():


### PR DESCRIPTION
## Changed 'search_id' to 'id' in scrub_target method in _uber.py
I altered the `field_mapping` dictionary in `scrub_target` to take the "id" keyword instead of "search_id" in the key named `GetSearchStatusV1`. I did some minor sanity testing afterwards and did confirm that the id is being properly placed in the URL path string now. 


- [x] Bug fixes 


#### Unit test coverage
See notes at the bottom of this PR.

#### Bandit analysis
```shell
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.12.10
Working... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:05
Run started:2025-05-08 13:23:29.966817

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 91376
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
Files skipped (0):

Formatting
--------------------------------------------------------
0
```


## Issues resolved
+ Fixes [#1329](https://github.com/CrowdStrike/falconpy/issues/1329) by changing the 'search_id' field value to 'id' for the `GetSearchStatusV1` entry in the `field_names` dictionary. 

## Other
#### Unit test coverage
I ran the unit test and got just around 50% coverage, but I believe that this is either due to:
- No API key
- I have no idea what I'm doing

In either case, if there's a dummy's guide to testing falconpy, I'd appreciate any guidance. I played around with it for a bit and couldn't figure out the issue.

#### Sanity Testing
I wrote a quick manual test to insure that everything was working. Thanks to @jshcodes for guiding me on this. Since we're just checking the URL, we can just enable logging and check the results.

```python
# sanity-test.py
logging.basicConfig(level=logging.DEBUG)
falcon = APIHarnessV2(client_id="", client_secret="", debug=True)
search_query = {"isLive": False, "start": "1d", "queryString": "#event_simpleName=*"}
response = falcon.command("GetSearchStatusV1", repository="string", id="testing123")
print(response)
```

Output:
```
-- snip --

DEBUG:urllib3.connectionpool:https://api.crowdstrike.com:443 "GET /humio/api/v1/repositories/string/queryjobs/testing123 HTTP/1.1" 401 231

--snip --

```

We can see that my testing id of "testing123" is appended to the URL.

#### Additional Items
The wiki and docs website will need to be updated, as they still show the Uber class being used with the `search_id` argument. I attempted to do this, but didn't see an obvious way to update the docs. If you can point me in the right direction, I will do so.
