### PR TITLE
allow "us-gov-2" CS_CLOUD env variable value

### DIFF
--- a/src/falconpy/_util/_functions.py
+++ b/src/falconpy/_util/_functions.py
@@ -799,7 +799,7 @@ def confirm_base_url(provided_base: Optional[str] = "https://api.crowdstrike.com
     try:
         if "://" not in provided_base:
             # They're passing the name instead of the URL
-            dashed_bases = ["US-1", "US-2", "EU-1", "US-GOV-1"]
+            dashed_bases = ["US-1", "US-2", "EU-1", "US-GOV-1", "US-GOV-2"]
             if provided_base.upper() in dashed_bases:
                 provided_base = provided_base.replace("-", "")  # Strip the dash
             try:


### PR DESCRIPTION
## Update cloud region shortnames
This update adds `us-gov-2` as an allowed shortname for the `USGOV2` value of the Base URL enumerator by updating the _confirm_base_url_ method.

- [x] Enhancement

## Added features and functionality
+ Added: Add `us-gov-2` as an allowed dashed_base within the _confirm_base_url_ method.
    - `_util/_functions.py`
