### PR TITLE
added `GetSensorUsageHourly` as this allows you to pull hourly billing based on Cloud calculated billing.

### DIFF
--- a/src/falconpy/_endpoint/_sensor_usage.py
+++ b/src/falconpy/_endpoint/_sensor_usage.py
@@ -58,5 +58,27 @@ _sensor_usage_endpoints = [
         "in": "query"
       }
     ]
+  ],
+  [
+    "GetSensorUsageHourly",
+    "GET",
+    "/billing-dashboards-usage/aggregates/hourly-average/v1",
+    "Fetches hourly average. Each data point represents the average of how many unique AIDs were seen per week "
+    "for the previous 28 days.",
+    "sensor_usage",
+    [
+      {
+        "type": "string",
+        "description": "The FQL search filter. Allowed fields:\n\"event_date\" : A specified date that will be "
+        " final date of the results returned. Specified date cannot be after the default.\n\tFormat: "
+        "'2024-06-11'\n\tDefault: the current date, minus 2 days, in UTC\n\"period\" : An integer surrounded by single "
+        "quotes representing the number of days to return.\n\tFormat: '30'\n\tDefault: '28'\n\tMinimum: '1'\n\tMaximum: "
+        " '395'\n\"selected_cids\" : A comma separated list of CIDs to return data for. Caller must be a parent CID or "
+        "have special access enabled.\n\tFormat: 'cid_1,cid_2,cid_3'\n\tDefault: for parent CIDs the default is the "
+        "parent and all children, otherwise the current CID",
+        "name": "filter",
+        "in": "query"
+      }
+    ]
   ]
 ]

--- a/src/falconpy/sensor_usage.py
+++ b/src/falconpy/sensor_usage.py
@@ -97,4 +97,48 @@ class SensorUsage(ServiceClass):
             params=parameters
             )
 
+    @force_default(defaults=["parameters"], default_types=["dict"])
+    def get_hourly_usage(self: object, parameters: dict = None, **kwargs) -> Union[Dict[str, Union[int, dict]], Result]:
+        """Fetch hourly sensor usage average used to measure cloud usage.
+
+        Each data point represents the average of how many unique AIDs were seen per week for the previous 28 days.
+
+        Keyword arguments:
+        filter -- The FQL search filter.
+                  Allowed fields:
+                    event_date - A specified date that will be final date of the results returned.
+                                 Specified date cannot be after the default.
+                                 Format: '2024-06-11'
+                                 Default: the current date, minus 2 days, in UTC
+                    period - An integer surrounded by single quotes representing the number of days to return.
+                             Format: '30'
+                             Default: '28'
+                             Minimum: '1'
+                             Maximum: '395'
+                    selected_cids - A comma delimited list of CIDs to return data for.
+                                    Caller must be a parent CID or have special access enabled.
+                                    Format: 'cid_1,cid_2,cid_3'
+                                    Default: for parent CIDs the default is the parent and all children,
+                                             otherwise the current CID
+        parameters -- Full parameters payload dictionary. Not required if using other keywords.
+
+        This method only supports keywords for providing arguments.
+
+        Returns: dict object containing API response.
+
+        HTTP Method: GET
+
+        Swagger URL
+        https://assets.falcon.crowdstrike.com/support/api/swagger.html#/sensor-usage-api/GetSensorUsageWeekly
+        Endpoint is not in Swagger file, but allows you to pull `hourly` usage which is used to determine cloud usage
+        """
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="GetSensorUsageHourly",
+            keywords=kwargs,
+            params=parameters
+            )
+
     GetSensorUsageWeekly = get_weekly_usage
+    GetSensorUsageHourly = get_hourly_usage

--- a/tests/test_sensor_usage.py
+++ b/tests/test_sensor_usage.py
@@ -23,7 +23,8 @@ class TestSensorUsage:
     def test_all_code_paths(self):
         error_checks = True
         tests = {
-            "GetWeeklySensorUsage": falcon.get_weekly_usage()
+            "GetWeeklySensorUsage": falcon.get_weekly_usage(),
+            "GetHourlySensorUsage": falcon.get_hourly_usage()
         }
         for key in tests:
             if tests[key]["status_code"] not in AllowedResponses:


### PR DESCRIPTION
# Add GetSensorUsageHourly
Added `GetSensorUsageHourly` to `_sensor_usage.py` endpoint; tested it in production, and works by providing either hourly or weekly billing usage depending on how billing is calculated. This is part of CrowdStrike documentation and also shows in the billing dashboard how these values are pulled. This helps calculate the **Cloud (reserved hourly) usage**. The endpoint that is not documented, but works along with getting weekly billing information is: `"/billing-dashboards-usage/aggregates/hourly-average/v1"`

- [X] Enhancement
- [X] Updated unit tests

#### Unit test coverage
```shell
pytest tests/test_sensor_usage.py -v
============================================================ test session starts ============================================================
cachedir: .pytest_cache
rootdir: /GitHub/falconpy
configfile: pyproject.toml
plugins: cov-6.3.0
collected 1 item                                                                                                                            

tests/test_sensor_usage.py::TestSensorUsage::test_all_code_paths PASSED                                                               [100%]

============================================================= 1 passed in 1.97s =============================================================
```

#### Bandit analysis
```shell
[main]	INFO	running on Python 3.13.3
Working... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:01
Run started:2025-11-05 19:15:54.058193

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 98726
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```
## Added features and functionality
+ If your PR adds features or functionality, what should be included in the next release notes?
Added support for pulling `hourly` billing data from `billing-dashboard-usage` endpoint on top of the weekly-average values.