### PR TITLE
Fix: Add pagination support to NGSIEM GetSearchStatusV1

### DIFF
--- a/src/falconpy/_endpoint/_ngsiem.py
+++ b/src/falconpy/_endpoint/_ngsiem.py
@@ -192,6 +192,18 @@ _ngsiem_endpoints = [
         "name": "id",
         "in": "path",
         "required": True
+      },
+      {
+        "type": "integer",
+        "description": "pagination limit",
+        "name": "paginationLimit",
+        "in": "query"
+      },
+      {
+        "type": "integer",
+        "description": "pagination offset",
+        "name": "paginationOffset",
+        "in": "query"
       }
     ]
   ],

--- a/src/falconpy/ngsiem.py
+++ b/src/falconpy/ngsiem.py
@@ -364,6 +364,10 @@ class NGSIEM(ServiceClass):
         repository -- Name of repository. String.
         id -- ID of the query. String. Can be used instead of search_id keyword.
         search_id -- ID of the query. String. Can be used instead of id keyword.
+        paginationLimit -- Optional pagination limit. Integer.
+        paginationOffset -- Optional pagination offset. Integer.
+        pagination_limit -- Optional pagination limit (alias for paginationLimit). Integer.
+        pagination_offset -- Optional pagination offset (alias for paginationOffset). Integer.
         parameters -- Full parameters payload dictionary. Not required if using other keywords.
 
         This method only supports keywords for providing arguments.
@@ -377,6 +381,11 @@ class NGSIEM(ServiceClass):
         """
         repository = kwargs.get("repository", None)
         search_id = kwargs.get("id", kwargs.get("search_id", None))
+        # Allow pythonic aliasing for query string parameters (Issue #1383)
+        if "pagination_limit" in kwargs and "paginationLimit" not in kwargs:
+            kwargs["paginationLimit"] = kwargs.pop("pagination_limit")
+        if "pagination_offset" in kwargs and "paginationOffset" not in kwargs:
+            kwargs["paginationOffset"] = kwargs.pop("pagination_offset")
         if repository and search_id:
             # Pop the path variables from the keywords dictionary
             # before processing query string arguments.

--- a/tests/test_ngsiem.py
+++ b/tests/test_ngsiem.py
@@ -149,3 +149,23 @@ class TestNGSIEM:
 
     def test_all_functionality(self):
         assert self.run_all_tests() is True
+
+    def test_pagination_params(self):
+        """Test that pagination parameters are properly handled (Issue #1383)."""
+        # Test with camelCase parameters
+        result = falcon.get_search_status(
+            repository="search-all",
+            id="test-id",
+            paginationLimit=100,
+            paginationOffset=0
+        )
+        assert result["status_code"] in AllowedResponses
+
+        # Test with pythonic parameters
+        result = falcon.get_search_status(
+            repository="search-all",
+            id="test-id",
+            pagination_limit=100,
+            pagination_offset=0
+        )
+        assert result["status_code"] in AllowedResponses


### PR DESCRIPTION
- Add paginationLimit and paginationOffset query parameters to GetSearchStatusV1 endpoint
- Add pythonic aliases (pagination_limit, pagination_offset) in NGSIEM.get_search_status()
- Add test coverage for pagination parameters
- Resolves #1383