### PR TITLE
Update hatch version in publishing workflows

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pipx install hatch==1.14.1
+        pipx install hatch==1.16.5
 
     - name: Build
       run: |

--- a/.github/workflows/development-edge.yml
+++ b/.github/workflows/development-edge.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pipx install hatch==1.14.1
+        pipx install hatch==1.16.5
 
     - name: Development package updates
       run: |

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -32,7 +32,7 @@ jobs:
         python-version: '3.11'
     - name: Install dependencies
       run: |
-        pipx install hatch==1.14.1
+        pipx install hatch==1.16.5
 
     - name: Development package updates
       run: |

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pipx install hatch==1.14.1
+        pipx install hatch==1.16.5
 
     - name: Build
       run: |


### PR DESCRIPTION
# Update publishing workflows
This pull request updates the hatch version in all publishing workflows.

- [x] Bug fixes 

#### Unit test coverage
```shell
NOT REQUIRED FOR NON-PACKAGE UPDATES
```

#### Bandit analysis
```shell
NOT REQUIRED FOR NON-PACKAGE UPDATES
```

## Other
+ Updated: Bump hatch version 1.14.1 -> 1.16.5

