### PR TITLE
Samples updates

### DIFF
--- a/samples/alerts/alerts_triage/alerts_triage.py
+++ b/samples/alerts/alerts_triage/alerts_triage.py
@@ -69,6 +69,7 @@ Architecture overview
 # pylint: disable=too-many-locals,too-few-public-methods
 # pylint: disable=too-many-instance-attributes,too-many-statements
 # pylint: disable=line-too-long  # ASCII banner in module docstring exceeds 100 chars
+# pylint: disable=import-error,no-name-in-module,unsupported-binary-operation
 import argparse
 import os
 import sys
@@ -108,22 +109,22 @@ SEVERITY_COLORS = {
     "4": "#E03030",   # high — red
     "5": "#990000",   # critical — dark red
     # Named severity labels (severity_name field)
-    "critical":      "#990000",
-    "high":          "#E03030",
-    "medium":        "#FF8C00",
-    "low":           "#F5E642",
+    "critical": "#990000",
+    "high": "#E03030",
+    "medium": "#FF8C00",
+    "low": "#F5E642",
     "informational": "#5B9BD5",
-    "unknown":       "#8E8E93",
+    "unknown": "#8E8E93",
 }
 
 # Text colour to use on each severity background (ensures contrast).
 SEVERITY_FG_COLORS = {
-    "critical":      "#FFFFFF",
-    "high":          "#FFFFFF",
-    "medium":        "#000000",
-    "low":           "#000000",
+    "critical": "#FFFFFF",
+    "high": "#FFFFFF",
+    "medium": "#000000",
+    "low": "#000000",
     "informational": "#000000",
-    "unknown":       "#FFFFFF",
+    "unknown": "#FFFFFF",
     "1": "#000000",
     "2": "#000000",
     "3": "#000000",
@@ -321,7 +322,7 @@ class AlertFetchWorker(QThread):
             for i in range(0, len(composite_ids), chunk_size):
                 if self._cancelled:
                     break
-                chunk = composite_ids[i : i + chunk_size]
+                chunk = composite_ids[i: i + chunk_size]
                 detail_resp = self._sdk.get_alerts_v2(composite_ids=chunk)
                 if detail_resp["status_code"] not in (200, 201):
                     raise RuntimeError(
@@ -774,8 +775,6 @@ class AlertsTriageApp(QMainWindow):
         self.setWindowTitle(f"Alerts Triage Dashboard — {label}")
         self._render_current_page()
 
-
-
     # ------------------------------------------------------------------
     # Pagination helpers
     # ------------------------------------------------------------------
@@ -936,40 +935,40 @@ class AlertsTriageApp(QMainWindow):
         lines.append("=" * 52)
         lines.append(f"Composite ID:  {alert.get('composite_id', '')}")
         lines.append("=" * 52)
-        _field("Severity",     "severity_name")
-        _field("Status",       "status")
-        _field("Name",         "name")
-        _field("Title",        "title")
-        _field("Tactic",       "tactic")
-        _field("Technique",    "technique")
+        _field("Severity", "severity_name")
+        _field("Status", "status")
+        _field("Name", "name")
+        _field("Title", "title")
+        _field("Tactic", "tactic")
+        _field("Technique", "technique")
         _field("Display Name", "display_name")
-        _field("Description",  "description")
+        _field("Description", "description")
         lines.append("")
         # Device fields (endpoint alerts)
         device = alert.get("device") or {}
         if device:
             lines.append("--- Device ---")
-            _field("Hostname",     "hostname",      device)
-            _field("AID",          "device_id",     device)
-            _field("OS",           "os_version",    device)
-            _field("Platform",     "platform_name", device)
+            _field("Hostname", "hostname", device)
+            _field("AID", "device_id", device)
+            _field("OS", "os_version", device)
+            _field("Platform", "platform_name", device)
             lines.append("")
         # Cloud / CWPP fields
         if alert.get("image_repository") or alert.get("cwpp_detect_id"):
             lines.append("--- Cloud / Image ---")
-            _field("Registry",     "image_registry")
-            _field("Repository",   "image_repository")
-            _field("Tag",          "image_tag")
-            _field("OS Name",      "os_name")
-            _field("OS Version",   "os_version")
-            _field("CWPP ID",      "cwpp_detect_id")
+            _field("Registry", "image_registry")
+            _field("Repository", "image_repository")
+            _field("Tag", "image_tag")
+            _field("OS Name", "os_name")
+            _field("OS Version", "os_version")
+            _field("CWPP ID", "cwpp_detect_id")
             lines.append("")
         lines.append("--- Timestamps ---")
-        _field("Created",      "created_timestamp")
-        _field("Updated",      "updated_timestamp")
+        _field("Created", "created_timestamp")
+        _field("Updated", "updated_timestamp")
         lines.append("")
         lines.append("--- Assignment ---")
-        _field("Assigned to",  "assigned_to_name")
+        _field("Assigned to", "assigned_to_name")
         _field("Assigned UID", "assigned_to_uid")
         comments = alert.get("comments") or []
         if comments:
@@ -1079,7 +1078,8 @@ class AlertsTriageApp(QMainWindow):
         """Cancel in-flight workers before closing to prevent signal-after-destroy crashes."""
         for worker in (self._fetch_worker, self._update_worker):
             if worker and worker.isRunning():
-                worker.cancel() if hasattr(worker, "cancel") else None
+                if hasattr(worker, "cancel"):
+                    worker.cancel()
                 worker.wait(2000)
         super().closeEvent(event)
 
@@ -1092,41 +1092,41 @@ def _dark_palette() -> QPalette:
     """Return a dark QPalette for use with the Fusion style."""
     p = QPalette()
     # Base colours
-    dark        = QColor(45,  45,  45)
-    mid_dark    = QColor(55,  55,  55)
-    mid         = QColor(65,  65,  65)
-    mid_light   = QColor(75,  75,  75)
-    light       = QColor(90,  90,  90)
-    text        = QColor(210, 210, 210)
-    dim_text    = QColor(140, 140, 140)
-    highlight   = QColor(42,  130, 218)
-    hi_text     = QColor(255, 255, 255)
-    link        = QColor(80,  160, 230)
+    dark = QColor(45, 45, 45)
+    mid_dark = QColor(55, 55, 55)
+    mid = QColor(65, 65, 65)
+    mid_light = QColor(75, 75, 75)
+    light = QColor(90, 90, 90)
+    text = QColor(210, 210, 210)
+    dim_text = QColor(140, 140, 140)
+    highlight = QColor(42, 130, 218)
+    hi_text = QColor(255, 255, 255)
+    link = QColor(80, 160, 230)
 
-    p.setColor(QPalette.ColorRole.Window,          dark)
-    p.setColor(QPalette.ColorRole.WindowText,      text)
-    p.setColor(QPalette.ColorRole.Base,            mid_dark)
-    p.setColor(QPalette.ColorRole.AlternateBase,   dark)
-    p.setColor(QPalette.ColorRole.ToolTipBase,     mid_dark)
-    p.setColor(QPalette.ColorRole.ToolTipText,     text)
-    p.setColor(QPalette.ColorRole.Text,            text)
-    p.setColor(QPalette.ColorRole.Button,          mid)
-    p.setColor(QPalette.ColorRole.ButtonText,      text)
-    p.setColor(QPalette.ColorRole.BrightText,      hi_text)
-    p.setColor(QPalette.ColorRole.Link,            link)
-    p.setColor(QPalette.ColorRole.Highlight,       highlight)
+    p.setColor(QPalette.ColorRole.Window, dark)
+    p.setColor(QPalette.ColorRole.WindowText, text)
+    p.setColor(QPalette.ColorRole.Base, mid_dark)
+    p.setColor(QPalette.ColorRole.AlternateBase, dark)
+    p.setColor(QPalette.ColorRole.ToolTipBase, mid_dark)
+    p.setColor(QPalette.ColorRole.ToolTipText, text)
+    p.setColor(QPalette.ColorRole.Text, text)
+    p.setColor(QPalette.ColorRole.Button, mid)
+    p.setColor(QPalette.ColorRole.ButtonText, text)
+    p.setColor(QPalette.ColorRole.BrightText, hi_text)
+    p.setColor(QPalette.ColorRole.Link, link)
+    p.setColor(QPalette.ColorRole.Highlight, highlight)
     p.setColor(QPalette.ColorRole.HighlightedText, hi_text)
     # Disabled state
     p.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText, dim_text)
-    p.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text,       dim_text)
+    p.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text, dim_text)
     p.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.ButtonText, dim_text)
-    p.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Button,     mid_light)
-    p.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Base,       mid_dark)
+    p.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Button, mid_light)
+    p.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Base, mid_dark)
     # Mid / shadow shades used by Fusion for borders and panel separators
-    p.setColor(QPalette.ColorRole.Mid,        light)
-    p.setColor(QPalette.ColorRole.Shadow,     QColor(20, 20, 20))
-    p.setColor(QPalette.ColorRole.Dark,       mid_dark)
-    p.setColor(QPalette.ColorRole.Midlight,   mid_light)
+    p.setColor(QPalette.ColorRole.Mid, light)
+    p.setColor(QPalette.ColorRole.Shadow, QColor(20, 20, 20))
+    p.setColor(QPalette.ColorRole.Dark, mid_dark)
+    p.setColor(QPalette.ColorRole.Midlight, mid_light)
     return p
 
 

--- a/samples/alerts/alerts_triage/alerts_triage.py
+++ b/samples/alerts/alerts_triage/alerts_triage.py
@@ -262,9 +262,12 @@ class AlertFetchWorker(QThread):
             if self._status:
                 clauses.append(f"status:'{self._status}'")
 
-            # Add default time window unless caller explicitly provided one in FQL
+            # Add default time window unless caller explicitly provided a timestamp clause.
+            # Match on field-name prefix followed by ':' to avoid false positives on
+            # hostnames or field names that happen to contain these substrings.
             has_time_filter = any(
-                kw in self._fql_filter for kw in ("created_timestamp", "timestamp", "last_")
+                f"{kw}:" in self._fql_filter
+                for kw in ("created_timestamp", "updated_timestamp", "timestamp", "last_seen")
             )
             if not has_time_filter and self._hours > 0:
                 since = datetime.now(timezone.utc) - timedelta(hours=self._hours)
@@ -298,7 +301,7 @@ class AlertFetchWorker(QThread):
                 composite_ids.extend(resources)
                 meta = body.get("meta", {}).get("pagination", {})
                 total = meta.get("total", 0)
-                last_api_offset = meta.get("offset", "")
+                last_api_offset = meta.get("offset", 0)
                 if not resources or len(composite_ids) >= total:
                     has_more = False
                     break
@@ -986,7 +989,7 @@ class AlertsTriageApp(QMainWindow):
 
     def _on_select_all(self, state: int) -> None:
         """Toggle selection on all rows when the select-all checkbox changes."""
-        if state == Qt.CheckState.Checked.value:
+        if Qt.CheckState(state) == Qt.CheckState.Checked:
             self._alert_table.selectAll()
         else:
             self._alert_table.clearSelection()
@@ -1067,6 +1070,18 @@ class AlertsTriageApp(QMainWindow):
         self.statusBar().showMessage(
             f"Total: {total}  |  Page {self._page_index + 1}/{total_pages}  |  Selected: {selected}"
         )
+
+    # ------------------------------------------------------------------
+    # Window lifecycle
+    # ------------------------------------------------------------------
+
+    def closeEvent(self, event) -> None:  # pylint: disable=invalid-name
+        """Cancel in-flight workers before closing to prevent signal-after-destroy crashes."""
+        for worker in (self._fetch_worker, self._update_worker):
+            if worker and worker.isRunning():
+                worker.cancel() if hasattr(worker, "cancel") else None
+                worker.wait(2000)
+        super().closeEvent(event)
 
 
 # ---------------------------------------------------------------------------

--- a/samples/device_control_policies/device_control_policy_manager/device_control_policy_manager.py
+++ b/samples/device_control_policies/device_control_policy_manager/device_control_policy_manager.py
@@ -85,7 +85,7 @@ import argparse
 import os
 import sys
 
-# pylint: disable=import-error
+# pylint: disable=import-error,no-name-in-module
 from PySide6.QtCore import (
     Qt, QThread, Signal, QSortFilterProxyModel,
 )
@@ -117,7 +117,7 @@ from PySide6.QtWidgets import (
 )
 
 from falconpy import DeviceControlPolicies, HostGroup
-# pylint: enable=import-error
+# pylint: enable=import-error,no-name-in-module
 
 # ── USB device class identifiers expected by the API ─────────────────────────
 DEVICE_CLASSES = [
@@ -529,7 +529,7 @@ class ExceptionDialog(QDialog):
             return
         try:
             val = int(vid, 16)
-            if not (0 <= val <= 0xFFFF):
+            if not 0 <= val <= 0xFFFF:
                 raise ValueError
         except ValueError:
             QMessageBox.warning(self, "Validation",
@@ -539,7 +539,7 @@ class ExceptionDialog(QDialog):
         if pid:
             try:
                 val = int(pid, 16)
-                if not (0 <= val <= 0xFFFF):
+                if not 0 <= val <= 0xFFFF:
                     raise ValueError
             except ValueError:
                 QMessageBox.warning(self, "Validation",

--- a/samples/device_control_policies/device_control_policy_manager/device_control_policy_manager.py
+++ b/samples/device_control_policies/device_control_policy_manager/device_control_policy_manager.py
@@ -466,54 +466,48 @@ class ExceptionDialog(QDialog):
 
         layout = QVBoxLayout(self)
 
-        # ── Class ────────────────────────────────────────────────────────────
         layout.addWidget(QLabel("Device Class *"))
-        self._class_combo = QComboBox()
-        self._class_combo.addItems(class_ids)
-        layout.addWidget(self._class_combo)
+        self.class_combo = QComboBox()
+        self.class_combo.addItems(class_ids)
+        layout.addWidget(self.class_combo)
 
-        # ── Vendor ───────────────────────────────────────────────────────────
         layout.addWidget(QLabel("Vendor ID  (4-digit hex, e.g. ffff)"))
-        self._vendor_id = QLineEdit()
-        self._vendor_id.setPlaceholderText("ffff")
-        layout.addWidget(self._vendor_id)
+        self.vendor_id = QLineEdit()
+        self.vendor_id.setPlaceholderText("ffff")
+        layout.addWidget(self.vendor_id)
 
         layout.addWidget(QLabel("Vendor Name"))
-        self._vendor_name = QLineEdit()
-        self._vendor_name.setPlaceholderText("e.g. Acme Corp")
-        layout.addWidget(self._vendor_name)
+        self.vendor_name = QLineEdit()
+        self.vendor_name.setPlaceholderText("e.g. Acme Corp")
+        layout.addWidget(self.vendor_name)
 
-        # ── Product ──────────────────────────────────────────────────────────
         layout.addWidget(QLabel("Product ID  (4-digit hex, e.g. abcd)"))
-        self._product_id = QLineEdit()
-        self._product_id.setPlaceholderText("abcd")
-        layout.addWidget(self._product_id)
+        self.product_id = QLineEdit()
+        self.product_id.setPlaceholderText("abcd")
+        layout.addWidget(self.product_id)
 
         layout.addWidget(QLabel("Product Name"))
-        self._product_name = QLineEdit()
-        self._product_name.setPlaceholderText("e.g. USB Drive")
-        layout.addWidget(self._product_name)
+        self.product_name = QLineEdit()
+        self.product_name.setPlaceholderText("e.g. USB Drive")
+        layout.addWidget(self.product_name)
 
-        # ── Action ───────────────────────────────────────────────────────────
         layout.addWidget(QLabel("Action *"))
-        self._action_combo = QComboBox()
-        self._action_combo.addItems(CLASS_ACTIONS)
-        layout.addWidget(self._action_combo)
+        self.action_combo = QComboBox()
+        self.action_combo.addItems(CLASS_ACTIONS)
+        layout.addWidget(self.action_combo)
 
-        # ── Optional fields ──────────────────────────────────────────────────
         layout.addWidget(QLabel("Serial Number  (optional)"))
-        self._serial = QLineEdit()
-        self._serial.setPlaceholderText("Leave blank to match any serial")
-        layout.addWidget(self._serial)
+        self.serial = QLineEdit()
+        self.serial.setPlaceholderText("Leave blank to match any serial")
+        layout.addWidget(self.serial)
 
         layout.addWidget(QLabel("Description  (optional)"))
-        self._description = QLineEdit()
-        layout.addWidget(self._description)
+        self.description = QLineEdit()
+        layout.addWidget(self.description)
 
-        self._use_wildcard = QCheckBox("Use wildcard matching")
-        layout.addWidget(self._use_wildcard)
+        self.use_wildcard = QCheckBox("Use wildcard matching")
+        layout.addWidget(self.use_wildcard)
 
-        # ── Buttons ──────────────────────────────────────────────────────────
         buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         )
@@ -523,7 +517,7 @@ class ExceptionDialog(QDialog):
 
     def _on_accept(self):
         """Validate vendor ID is present and is valid 4-digit hex before accepting."""
-        vid = self._vendor_id.text().strip()
+        vid = self.vendor_id.text().strip()
         if not vid:
             QMessageBox.warning(self, "Validation", "Vendor ID is required.")
             return
@@ -535,7 +529,7 @@ class ExceptionDialog(QDialog):
             QMessageBox.warning(self, "Validation",
                                 "Vendor ID must be a 4-digit hexadecimal value (e.g. ffff).")
             return
-        pid = self._product_id.text().strip()
+        pid = self.product_id.text().strip()
         if pid:
             try:
                 val = int(pid, 16)
@@ -546,53 +540,6 @@ class ExceptionDialog(QDialog):
                                     "Product ID must be a 4-digit hexadecimal value (e.g. abcd).")
                 return
         self.accept()
-
-    # ── Properties used by caller ─────────────────────────────────────────────
-
-    @property
-    def class_id(self):
-        """Return the selected device class ID."""
-        return self._class_combo.currentText()
-
-    @property
-    def vendor_id(self):
-        """Return the entered vendor ID string."""
-        return self._vendor_id.text().strip()
-
-    @property
-    def vendor_name(self):
-        """Return the entered vendor name."""
-        return self._vendor_name.text().strip()
-
-    @property
-    def product_id(self):
-        """Return the entered product ID string."""
-        return self._product_id.text().strip()
-
-    @property
-    def product_name(self):
-        """Return the entered product name."""
-        return self._product_name.text().strip()
-
-    @property
-    def action(self):
-        """Return the selected action string."""
-        return self._action_combo.currentText()
-
-    @property
-    def serial_number(self):
-        """Return the entered serial number (empty string if blank)."""
-        return self._serial.text().strip()
-
-    @property
-    def description(self):
-        """Return the entered description."""
-        return self._description.text().strip()
-
-    @property
-    def use_wildcard(self):
-        """Return True if the wildcard checkbox is checked."""
-        return self._use_wildcard.isChecked()
 
 
 # ── New / Edit policy dialog ──────────────────────────────────────────────────
@@ -1181,19 +1128,19 @@ class DeviceControlWindow(QMainWindow):
         orig_map = {c.get("id", ""): dict(c) for c in original_classes}
 
         new_exc = {
-            "vendor_id": dlg.vendor_id,
-            "vendor_name": dlg.vendor_name,
-            "product_id": dlg.product_id,
-            "product_name": dlg.product_name,
-            "action": dlg.action,
-            "use_wildcard": dlg.use_wildcard,
+            "vendor_id": dlg.vendor_id.text().strip(),
+            "vendor_name": dlg.vendor_name.text().strip(),
+            "product_id": dlg.product_id.text().strip(),
+            "product_name": dlg.product_name.text().strip(),
+            "action": dlg.action_combo.currentText(),
+            "use_wildcard": dlg.use_wildcard.isChecked(),
         }
-        if dlg.serial_number:
-            new_exc["serial_number"] = dlg.serial_number
-        if dlg.description:
-            new_exc["description"] = dlg.description
+        if dlg.serial.text().strip():
+            new_exc["serial_number"] = dlg.serial.text().strip()
+        if dlg.description.text().strip():
+            new_exc["description"] = dlg.description.text().strip()
 
-        target_class_id = dlg.class_id
+        target_class_id = dlg.class_combo.currentText()
         if target_class_id not in orig_map:
             orig_map[target_class_id] = {"id": target_class_id, "action": "FULL_ACCESS"}
 

--- a/samples/device_control_policies/device_control_policy_manager/device_control_policy_manager.py
+++ b/samples/device_control_policies/device_control_policy_manager/device_control_policy_manager.py
@@ -73,7 +73,7 @@ Architecture overview
     LoadPoliciesWorker   — calls query_combined_policies (paginated)
     SavePolicyWorker     — calls create_policies or update_policies
     DeletePolicyWorker   — calls delete_policies
-    ActionWorker         — calls performDeviceControlPoliciesAction (enable/disable/assign group)
+    ActionWorker         — calls perform_action (enable/disable/assign group)
     LoadGroupsWorker     — calls HostGroup.query_combined_host_groups
 """
 # pylint: disable=too-many-lines
@@ -272,7 +272,7 @@ class ActionWorker(QThread):
         self._group_id = group_id
 
     def run(self):
-        """Call performDeviceControlPoliciesAction with the requested action."""
+        """Call perform_action with the requested action."""
         try:
             kwargs = {
                 "action_name": self._action_name,
@@ -283,7 +283,7 @@ class ActionWorker(QThread):
                     {"name": "group_id", "value": self._group_id}
                 ]
 
-            response = self._sdk.performDeviceControlPoliciesAction(**kwargs)
+            response = self._sdk.perform_action(**kwargs)
             status = response.get("status_code", 0)
             if status != 200:
                 errors = response.get("body", {}).get("errors", [])
@@ -522,10 +522,29 @@ class ExceptionDialog(QDialog):
         layout.addWidget(buttons)
 
     def _on_accept(self):
-        """Validate that at least vendor ID is provided before accepting."""
-        if not self._vendor_id.text().strip():
+        """Validate vendor ID is present and is valid 4-digit hex before accepting."""
+        vid = self._vendor_id.text().strip()
+        if not vid:
             QMessageBox.warning(self, "Validation", "Vendor ID is required.")
             return
+        try:
+            val = int(vid, 16)
+            if not (0 <= val <= 0xFFFF):
+                raise ValueError
+        except ValueError:
+            QMessageBox.warning(self, "Validation",
+                                "Vendor ID must be a 4-digit hexadecimal value (e.g. ffff).")
+            return
+        pid = self._product_id.text().strip()
+        if pid:
+            try:
+                val = int(pid, 16)
+                if not (0 <= val <= 0xFFFF):
+                    raise ValueError
+            except ValueError:
+                QMessageBox.warning(self, "Validation",
+                                    "Product ID must be a 4-digit hexadecimal value (e.g. abcd).")
+                return
         self.accept()
 
     # ── Properties used by caller ─────────────────────────────────────────────
@@ -1549,6 +1568,13 @@ class DeviceControlWindow(QMainWindow):
             self._btn_enable.setEnabled(False)
             self._btn_disable.setEnabled(False)
 
+    def closeEvent(self, event):  # pylint: disable=invalid-name
+        """Stop active background workers before closing to prevent use-after-free crashes."""
+        for worker in list(self._active_workers):
+            if worker.isRunning():
+                worker.wait(2000)
+        super().closeEvent(event)
+
 
 # ── Entry point ───────────────────────────────────────────────────────────────
 
@@ -1599,17 +1625,13 @@ def main():
         )
         sys.exit(1)
 
-    # Build SDK instances; both share the same credential pair
+    # Build SDK instances; group_sdk shares the auth token from sdk.
     sdk = DeviceControlPolicies(
         client_id=client_id,
         client_secret=client_secret,
         base_url=base_url,
     )
-    group_sdk = HostGroup(
-        client_id=client_id,
-        client_secret=client_secret,
-        base_url=base_url,
-    )
+    group_sdk = HostGroup(auth_object=sdk)
 
     app = QApplication(sys.argv)
     app.setApplicationName("Device Control Policy Manager")

--- a/samples/filevantage/filevantage_monitor/filevantage_monitor.py
+++ b/samples/filevantage/filevantage_monitor/filevantage_monitor.py
@@ -91,6 +91,7 @@ import json
 import math
 import os
 import sys
+import time
 from argparse import ArgumentParser, RawTextHelpFormatter
 from datetime import datetime
 
@@ -182,7 +183,7 @@ _DEMO_CHANGES = [
         "entity_type": "FILE",
         "severity": "HIGH",
         "file_name": "svchost.dll",
-        "file_path": "C:\\Windows\\System32\\svchost.dll",
+        "entity_path": "C:\\Windows\\System32\\svchost.dll",
         "process_image_file_name": "installer.exe",
         "user_name": "SYSTEM",
         "sha256_hash_before": "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
@@ -199,7 +200,7 @@ _DEMO_CHANGES = [
         "entity_type": "FILE",
         "severity": "MEDIUM",
         "file_name": "passwd",
-        "file_path": "/etc/passwd",
+        "entity_path": "/etc/passwd",
         "process_image_file_name": "rm",
         "user_name": "root",
         "sha256_hash_before": "111222333444111222333444111222333444111222333444111222333444111f",
@@ -216,7 +217,7 @@ _DEMO_CHANGES = [
         "entity_type": "FILE",
         "severity": "LOW",
         "file_name": "backdoor.sh",
-        "file_path": "/tmp/backdoor.sh", # nosec - Ridiculous Bandit FP
+        "entity_path": "/tmp/backdoor.sh", # nosec - Ridiculous Bandit FP
         "process_image_file_name": "bash",
         "user_name": "www-data",
         "sha256_hash_before": "",
@@ -233,7 +234,7 @@ _DEMO_CHANGES = [
         "entity_type": "FILE",
         "severity": "MEDIUM",
         "file_name": "config.bak",
-        "file_path": "C:\\Users\\alice\\Documents\\config.bak",
+        "entity_path": "C:\\Users\\alice\\Documents\\config.bak",
         "process_image_file_name": "explorer.exe",
         "user_name": "alice",
         "sha256_hash_before": "aaaa1111bbbb2222cccc3333dddd4444aaaa1111bbbb2222cccc3333dddd4444",
@@ -371,28 +372,22 @@ class FetchChangesWorker(QThread):
     finished = pyqtSignal(list, int, bool)
     error = pyqtSignal(str)
 
-    def __init__(self, client_id: str, client_secret: str, base_url: str,
-                 fql_filter: str, start_offset: int = 0, parent=None) -> None:
-        """Initialise the worker with Falcon API credentials and an optional FQL filter.
+    def __init__(self, sdk: "FileVantage", fql_filter: str,
+                 start_offset: int = 0, parent=None) -> None:
+        """Initialise the worker with an authenticated SDK instance and an optional FQL filter.
 
         *start_offset* is the API offset to begin from (0 for a fresh load,
         non-zero to continue fetching after a previous batch).
         """
         super().__init__(parent)
-        self._client_id = client_id
-        self._client_secret = client_secret
-        self._base_url = base_url
+        self._sdk = sdk
         self._fql_filter = fql_filter
         self._start_offset = start_offset
 
     def run(self) -> None:  # pylint: disable=too-many-branches
-        """Authenticate, paginate through FileVantage change IDs, hydrate, and emit results."""
+        """Paginate through FileVantage change IDs, hydrate, and emit results."""
         try:
-            sdk = FileVantage(
-                client_id=self._client_id,
-                client_secret=self._client_secret,
-                base_url=self._base_url,
-            )
+            sdk = self._sdk
 
             # Page through query_changes in _PAGE_SIZE chunks until we have
             # _MAX_CHANGES IDs or the API signals no more results.
@@ -444,7 +439,6 @@ class FetchChangesWorker(QThread):
 
             # Hydrate IDs in batches of 100 (get_changes API limit).
             changes: list[dict] = []
-            debug_printed = False
             for i in range(0, len(all_ids), _PAGE_SIZE):
                 if self.isInterruptionRequested():
                     return
@@ -461,15 +455,6 @@ class FetchChangesWorker(QThread):
                     return
 
                 resources = body.get("resources", []) or []
-
-                # Debug: print the first raw resource so field names can be verified
-                # if unexpected columns appear empty.
-                if not debug_printed and resources:
-                    debug_printed = True
-                    print("[FileVantage DEBUG] First change keys:", list(resources[0].keys()))
-                    truncated = dict(list(resources[0].items())[:15])
-                    print("[FileVantage DEBUG] First change (truncated):",
-                          json.dumps(truncated, indent=2, default=str))
 
                 for resource in resources:
                     # Attach raw JSON for the detail dialog's JSON tab.
@@ -515,7 +500,6 @@ class SuppressWorker(QThread):
 
     def run(self) -> None:
         """Submit the action via start_actions, then poll get_actions for status."""
-        import time  # pylint: disable=import-outside-toplevel
         try:
             sdk = FileVantage(
                 client_id=self._client_id,
@@ -896,6 +880,13 @@ class FileVantageWindow(QMainWindow):
         self._bulk_change_ids: list[str] = []
 
         self._demo_mode = not (self._client_id and self._client_secret)
+        self._sdk: FileVantage | None = None
+        if not self._demo_mode:
+            self._sdk = FileVantage(
+                client_id=self._client_id,
+                client_secret=self._client_secret,
+                base_url=self._base_url,
+            )
 
         self._build_ui()
         self._start_auto_refresh()
@@ -1099,7 +1090,7 @@ class FileVantageWindow(QMainWindow):
         for worker in (self._fetch_worker, self._suppress_worker):
             if worker and worker.isRunning():
                 worker.requestInterruption()
-                worker.wait()  # Block until the thread exits (no timeout — must finish).
+                worker.wait(5000)  # 5s timeout; OS reclaims thread on process exit if exceeded.
         super().closeEvent(event)
 
     # ── Auto-refresh timer ────────────────────────────────────────────────────
@@ -1246,9 +1237,7 @@ class FileVantageWindow(QMainWindow):
 
         fql = self._fql_input.text().strip()
         self._fetch_worker = FetchChangesWorker(
-            client_id=self._client_id,
-            client_secret=self._client_secret,
-            base_url=self._base_url,
+            sdk=self._sdk,
             fql_filter=fql,
             start_offset=0,
             parent=self,
@@ -1271,9 +1260,7 @@ class FileVantageWindow(QMainWindow):
 
         fql = self._fql_input.text().strip()
         self._fetch_worker = FetchChangesWorker(
-            client_id=self._client_id,
-            client_secret=self._client_secret,
-            base_url=self._base_url,
+            sdk=self._sdk,
             fql_filter=fql,
             start_offset=self._api_offset,
             parent=self,

--- a/samples/filevantage/filevantage_monitor/filevantage_monitor.py
+++ b/samples/filevantage/filevantage_monitor/filevantage_monitor.py
@@ -82,7 +82,7 @@ Architecture overview
   API calls run on a background QThread (FetchChangesWorker) and deliver
   results back to the main thread via Qt signals, keeping the UI responsive.
 """
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,unsupported-binary-operation
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 # pylint: disable=too-many-locals,too-few-public-methods
 # pylint: disable=too-many-instance-attributes,too-many-statements
@@ -95,7 +95,7 @@ import time
 from argparse import ArgumentParser, RawTextHelpFormatter
 from datetime import datetime
 
-# pylint: disable=import-error
+# pylint: disable=import-error,no-name-in-module
 from PyQt6.QtCore import (
     Qt, QThread, pyqtSignal, QTimer, QSortFilterProxyModel,
 )
@@ -125,7 +125,7 @@ from PyQt6.QtWidgets import (
 )
 
 from falconpy import FileVantage
-# pylint: enable=import-error
+# pylint: enable=import-error,no-name-in-module
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
@@ -217,7 +217,7 @@ _DEMO_CHANGES = [
         "entity_type": "FILE",
         "severity": "LOW",
         "file_name": "backdoor.sh",
-        "entity_path": "/tmp/backdoor.sh", # nosec - Ridiculous Bandit FP
+        "entity_path": "/tmp/backdoor.sh",  # nosec - Ridiculous Bandit FP
         "process_image_file_name": "bash",
         "user_name": "www-data",
         "sha256_hash_before": "",
@@ -304,7 +304,7 @@ def _get_nested(obj: dict, *keys: str, default: str = "") -> str:
 
 
 def _resolve_file_path(change: dict) -> str:
-    """Extract the file path from a change resource.
+    r"""Extract the file path from a change resource.
 
     The FileVantage getChanges API returns the path in ``entity_path``
     (confirmed against live API — field contains the full device path,
@@ -442,7 +442,7 @@ class FetchChangesWorker(QThread):
             for i in range(0, len(all_ids), _PAGE_SIZE):
                 if self.isInterruptionRequested():
                     return
-                batch = all_ids[i : i + _PAGE_SIZE]
+                batch = all_ids[i: i + _PAGE_SIZE]
                 resp = sdk.get_changes(ids=batch)
                 status = resp.get("status_code", 0)
                 body = resp.get("body", {})
@@ -825,7 +825,7 @@ class FileVantageWindow(QMainWindow):
     - Dispatch Suppress / Export actions.
     """
 
-    def __init__(self, client_id: str = "", client_secret: str = "", # nosec - Bandit FP
+    def __init__(self, client_id: str = "", client_secret: str = "",  # nosec - Bandit FP
                  base_url: str = "") -> None:
         """Initialise window, read credentials, build UI, trigger first load.
 

--- a/samples/hosts/high_activity_hosts.py
+++ b/samples/hosts/high_activity_hosts.py
@@ -87,6 +87,10 @@ Optional (for interactive mode):
 Created by: Manjula Wickramasuriya (@Manjula101) - Enterprise Security Lab
 Modified and then overarchitected by: jshcodes@CrowdStrike
 """
+# pylint: disable=too-many-lines,invalid-name,import-outside-toplevel
+# pylint: disable=global-statement,broad-exception-caught
+# pylint: disable=too-many-locals,too-many-branches,too-many-statements
+# pylint: disable=too-many-nested-blocks,unused-argument
 import os
 import sys
 import csv
@@ -400,9 +404,9 @@ def generate_demo_data(limit: int) -> List[Dict]:
         # and export_to_csv reference
         demo_hosts.append({
             # Zero-padded hostname for consistent column width
-            'hostname': f'HOST{str(i+1).zfill(6)}.example.com',
+            'hostname': f'HOST{str(i + 1).zfill(6)}.example.com',
             # Fake device ID; zero-padded to 32 chars like a real UUID
-            'device_id': f'demo{str(i+1).zfill(32)}',
+            'device_id': f'demo{str(i + 1).zfill(32)}',
             'alerts': total_alerts,
             'severity_breakdown': severity_breakdown,
             'rtr_sessions': rtr_sessions,
@@ -477,7 +481,7 @@ def fetch_device_details(
     # within the Falcon API's per-call payload limit
     batch_size = 5000
     batches = [
-        device_ids[i:i+batch_size]
+        device_ids[i:i + batch_size]
         for i in range(0, len(device_ids), batch_size)
     ]
 
@@ -555,14 +559,13 @@ def fetch_device_details(
     return hosts_by_id
 
 
-def query_high_activity_hosts(
+def query_high_activity_hosts(  # noqa: C901
     hosts_api: "Hosts",
     alerts_api: "Alerts",
     rtr_api: Optional["RealTimeResponseAudit"],
     days: int,
     limit: int,
     additional_filter: Optional[str] = None,
-    max_workers: int = 10,
     spotlight_api=None,
     zta_api=None
 ) -> List[Dict]:
@@ -833,7 +836,7 @@ def query_high_activity_hosts(
     return enriched_hosts[:limit], len(enriched_hosts)
 
 
-def count_alerts_by_host(
+def count_alerts_by_host(  # noqa: C901
     alerts_api: "Alerts",
     device_ids: List[str],
     start_date: datetime,
@@ -1129,7 +1132,7 @@ def count_rtr_sessions_by_host(
     return dict(session_counts)
 
 
-def fetch_spotlight_by_host(
+def fetch_spotlight_by_host(  # noqa: C901
     spotlight_api: "SpotlightVulnerabilities",
     device_ids: List[str],
     incremental_callback=None
@@ -1527,6 +1530,7 @@ def query_hosts_fast(
     end_date = datetime.now(timezone.utc)
     start_date = end_date - timedelta(days=days)
     # Build FQL date filter: only hosts seen within the window
+    date_filter = f"last_seen:>='{start_date.strftime('%Y-%m-%d')}'"
 
     # Combine with any user-supplied FQL filter using '+' (FQL AND)
     fql_filter = date_filter
@@ -1602,7 +1606,7 @@ def query_hosts_fast(
     return hosts_by_id, all_device_ids, start_date
 
 
-def enrich_hosts_background(
+def enrich_hosts_background(  # noqa: C901
     hosts_by_id: Dict[str, Dict],
     all_device_ids: List[str],
     start_date: datetime,
@@ -1610,7 +1614,6 @@ def enrich_hosts_background(
     rtr_api: Optional["RealTimeResponseAudit"],
     loading_state,
     days: int,
-    max_workers: int = 10,
     spotlight_api=None,
     zta_api=None
 ):
@@ -2173,7 +2176,7 @@ def export_to_csv(
         raise SystemExit(1) from err
 
 
-def main():
+def main():  # noqa: C901
     """Run the high activity hosts analysis.
 
     Orchestrates the full pipeline:
@@ -2404,7 +2407,6 @@ def main():
                         rtr_api,
                         loading_state,
                         args.days,
-                        args.workers,
                         spotlight_api,
                         zta_api
                     ),
@@ -2445,7 +2447,7 @@ def main():
                 hosts, total_analyzed = query_high_activity_hosts(
                     hosts_api, alerts_api, rtr_api,
                     args.days, args.limit,
-                    args.filter, args.workers,
+                    args.filter,
                     spotlight_api=spotlight_api,
                     zta_api=zta_api
                 )

--- a/samples/hosts/high_activity_hosts.py
+++ b/samples/hosts/high_activity_hosts.py
@@ -91,12 +91,12 @@ import os
 import sys
 import csv
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from argparse import ArgumentParser, RawTextHelpFormatter, Namespace
 from typing import List, Dict, Optional
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from threading import Lock, Thread
+from threading import Thread
 
 # Deferred imports: these are set to None at module level so the script can
 # display --help output without requiring third-party packages to be installed.
@@ -333,7 +333,7 @@ def generate_demo_data(limit: int) -> List[Dict]:
     # Cycle through platforms to simulate a heterogeneous environment
     platforms = ['Windows', 'Linux', 'Mac']
     # Anchor point for computing relative last_seen timestamps
-    base_date = datetime.utcnow()
+    base_date = datetime.now(timezone.utc)
 
     for i in range(limit):
         # Create a declining alert count with periodic bumps (i % 5)
@@ -389,8 +389,12 @@ def generate_demo_data(limit: int) -> List[Dict]:
         elif zta_overall < 60:
             activity_score += 15
         # Recent hosts get a bonus, matching the real scoring logic
-        if hours_since < 24:
+        if hours_since < 1:
+            activity_score += 100
+        elif hours_since < 24:
             activity_score += 50
+        elif hours_since < 72:
+            activity_score += 25
 
         # Build the host dict with all fields that display_results
         # and export_to_csv reference
@@ -592,7 +596,7 @@ def query_high_activity_hosts(
                contains at most ``limit`` host dicts sorted by score.
     """
     # Calculate the date range for the query — all timestamps are UTC
-    end_date = datetime.utcnow()
+    end_date = datetime.now(timezone.utc)
     start_date = end_date - timedelta(days=days)
     # FQL (Falcon Query Language) date filter using '>=' for inclusive start
     date_filter = f"last_seen:>='{start_date.strftime('%Y-%m-%d')}'"
@@ -688,7 +692,6 @@ def query_high_activity_hosts(
             alerts_api,
             all_device_ids,
             start_date,
-            max_workers
         )
         future_to_step[future_alerts] = 'alerts'
 
@@ -834,7 +837,6 @@ def count_alerts_by_host(
     alerts_api: "Alerts",
     device_ids: List[str],
     start_date: datetime,
-    max_workers: int = 10,
     quiet: bool = False,
     progress_callback=None,
     incremental_callback=None
@@ -1463,7 +1465,7 @@ def calculate_activity_score(host: Dict, days: int) -> int:
             )
             # Calculate hours elapsed since the host last reported in
             hours_since = (
-                (datetime.utcnow() - last_seen_dt).total_seconds()
+                (datetime.now(timezone.utc) - last_seen_dt).total_seconds()
                 / 3600
             )
             # Tiered bonus: more recent = higher bonus
@@ -1522,10 +1524,9 @@ def query_hosts_fast(
                enrichment.
     """
     # Compute the UTC date window for the FQL filter
-    end_date = datetime.utcnow()
+    end_date = datetime.now(timezone.utc)
     start_date = end_date - timedelta(days=days)
     # Build FQL date filter: only hosts seen within the window
-    date_filter = f"last_seen:>='{start_date.strftime('%Y-%m-%d')}'"
 
     # Combine with any user-supplied FQL filter using '+' (FQL AND)
     fql_filter = date_filter
@@ -1866,7 +1867,7 @@ def enrich_hosts_background(
     # --- Alerts: run in this thread with incremental callbacks ---
     try:
         alert_counts, severity_counts, _ = count_alerts_by_host(
-            alerts_api, all_device_ids, start_date, max_workers,
+            alerts_api, all_device_ids, start_date,
             quiet=True,
             progress_callback=loading_state.update_alerts,
             incremental_callback=_apply_partial_alerts
@@ -2158,7 +2159,7 @@ def export_to_csv(
                 total_rtr = sum(h['rtr_sessions'] for h in hosts)
                 csvfile.write(f"# Total RTR sessions: {total_rtr:,}\n")
             # Record generation timestamp for audit trail
-            timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+            timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
             csvfile.write(f"# Generated: {timestamp} UTC\n")
 
         # Confirm successful export to the user
@@ -2593,6 +2594,4 @@ if __name__ == "__main__":
         # Flush output before exit so buffered text (tables, etc.) is visible
         sys.stdout.flush()
         sys.stderr.flush()
-        # Use os._exit to avoid hanging on atexit handlers from
-        # ThreadPoolExecutor or background daemon threads
-        os._exit(_exit_code)  # pylint: disable=protected-access
+        sys.exit(_exit_code)

--- a/samples/ods/ods_manager/ods_manager.py
+++ b/samples/ods/ods_manager/ods_manager.py
@@ -259,7 +259,7 @@ class ODSClient:
                 self.status = "error"
                 return False
             self._sdk = sdk
-            self._hosts_sdk = Hosts(client_id=client_id, client_secret=client_secret)
+            self._hosts_sdk = Hosts(auth_object=sdk)
             self.status = "connected"
             self.error = ""
             return True
@@ -851,9 +851,10 @@ class ODSManagerFrame(wx.Frame):
 
     def _async_refresh(self):
         """Kick off a background thread to reload the scan list."""
-        if self._loading:
-            return
-        self._loading = True
+        with self._lock:
+            if self._loading:
+                return
+            self._loading = True
         self._set_status("Loading…", wx.Colour(180, 180, 180))
         t = threading.Thread(target=self._worker_refresh, daemon=True)
         t.start()
@@ -874,7 +875,8 @@ class ODSManagerFrame(wx.Frame):
         except Exception as exc:  # pylint: disable=broad-except
             wx.CallAfter(self._set_status, f"Error: {exc}", wx.Colour(220, 50, 50))
         finally:
-            self._loading = False
+            with self._lock:
+                self._loading = False
 
     def _populate_scan_list(self, scans: list[ScanRecord], ts: str):
         """Rebuild the scan list control from *scans* (runs on main thread)."""
@@ -1062,12 +1064,14 @@ class ODSManagerFrame(wx.Frame):
         dlg.Destroy()
 
         if not hosts and not groups:
-            wx.MessageDialog(
+            _dlg = wx.MessageDialog(
                 self,
                 "Please enter at least one host AID or host group ID.",
                 "Validation Error",
                 wx.OK | wx.ICON_WARNING,
-            ).ShowModal()
+            )
+            _dlg.ShowModal()
+            _dlg.Destroy()
             # Re-open with same values so user can correct
             self._show_new_scan_dialog(available_hosts, prefill={
                 "use_groups": bool(groups),
@@ -1082,13 +1086,15 @@ class ODSManagerFrame(wx.Frame):
             return
 
         if not file_paths:
-            wx.MessageDialog(
+            _dlg = wx.MessageDialog(
                 self,
                 "At least one file path is required.\n"
                 "Add a path (e.g. C:\\ or /) before starting the scan.",
                 "Validation Error",
                 wx.OK | wx.ICON_WARNING,
-            ).ShowModal()
+            )
+            _dlg.ShowModal()
+            _dlg.Destroy()
             self._show_new_scan_dialog(available_hosts, prefill={
                 "use_groups": bool(groups),
                 "aids": "\n".join(hosts),
@@ -1113,7 +1119,9 @@ class ODSManagerFrame(wx.Frame):
             )
         )
         icon = wx.ICON_INFORMATION if ok else wx.ICON_ERROR
-        wx.MessageDialog(self, msg, "New Scan", wx.OK | icon).ShowModal()
+        _dlg = wx.MessageDialog(self, msg, "New Scan", wx.OK | icon)
+        _dlg.ShowModal()
+        _dlg.Destroy()
         if ok:
             self._async_refresh()
         else:
@@ -1133,8 +1141,9 @@ class ODSManagerFrame(wx.Frame):
         """Cancel the selected scan if it is active."""
         scan_id = self._get_selected_scan_id()
         if not scan_id:
-            wx.MessageDialog(self, "No scan selected.", "Cancel Scan",
-                             wx.OK | wx.ICON_WARNING).ShowModal()
+            _dlg = wx.MessageDialog(self, "No scan selected.", "Cancel Scan", wx.OK | wx.ICON_WARNING)
+            _dlg.ShowModal()
+            _dlg.Destroy()
             return
 
         # Resolve truncated ID against the full list
@@ -1153,7 +1162,9 @@ class ODSManagerFrame(wx.Frame):
 
         ok, msg = self._client.cancel_scans([full_id])
         icon = wx.ICON_INFORMATION if ok else wx.ICON_ERROR
-        wx.MessageDialog(self, msg, "Cancel Scan", wx.OK | icon).ShowModal()
+        _dlg = wx.MessageDialog(self, msg, "Cancel Scan", wx.OK | icon)
+        _dlg.ShowModal()
+        _dlg.Destroy()
         if ok:
             self._async_refresh()
 
@@ -1196,12 +1207,14 @@ class ODSManagerFrame(wx.Frame):
                 self._on_cancel_selected(_event)
         else:
             # Completed/failed/cancelled scan: nothing can be done
-            wx.MessageDialog(
+            _dlg = wx.MessageDialog(
                 self,
                 "On-demand scan records cannot be deleted.",
                 "Delete Not Supported",
                 wx.OK | wx.ICON_INFORMATION,
-            ).ShowModal()
+            )
+            _dlg.ShowModal()
+            _dlg.Destroy()
 
     def _resolve_full_id(self, truncated: str) -> Optional[str]:
         """Find the full scan_id in self._scans matching the (possibly truncated) display value."""
@@ -1249,7 +1262,7 @@ def main():
     ok = client.connect(client_id=args.client_id, client_secret=args.client_secret)
     if not ok:
         # Show the auth error before opening the main window
-        wx.MessageDialog(
+        _dlg = wx.MessageDialog(
             None,
             f"Authentication failed:\n\n{client.error}\n\n"
             "Provide credentials via environment variables or -k / -s arguments:\n"
@@ -1257,7 +1270,9 @@ def main():
             "  pipenv run python3 ods_manager.py -k CLIENT_ID -s CLIENT_SECRET",
             "ODS Manager — Auth Error",
             wx.OK | wx.ICON_ERROR,
-        ).ShowModal()
+        )
+        _dlg.ShowModal()
+        _dlg.Destroy()
         sys.exit(1)
 
     frame = ODSManagerFrame(client)

--- a/samples/ods/ods_manager/ods_manager.py
+++ b/samples/ods/ods_manager/ods_manager.py
@@ -49,7 +49,7 @@ Required API scopes
   on-demand-scans:read
   on-demand-scans:write
 """
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,unsupported-binary-operation
 # pylint: disable=too-many-locals,too-many-statements
 # pylint: disable=too-many-instance-attributes,too-many-branches
 # pylint: disable=too-few-public-methods
@@ -62,9 +62,11 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
 
+# pylint: disable=import-error
 import wx
 import wx.lib.mixins.listctrl as listmix
 from falconpy import Hosts, ODS
+# pylint: enable=import-error
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -85,34 +87,34 @@ ACTIVE_STATUSES = {"pending_stop", "running", "pending", "queued"}
 
 # Colour table used to tint status text in the scan list
 STATUS_COLOURS = {
-    "running":       wx.Colour(50, 200, 80),
-    "complete":      wx.Colour(100, 180, 255),
-    "failed":        wx.Colour(220, 50, 50),
-    "cancelled":     wx.Colour(180, 130, 50),
-    "pending_stop":  wx.Colour(220, 200, 50),
-    "queued":        wx.Colour(180, 180, 180),
-    "pending":       wx.Colour(180, 180, 180),
+    "running": wx.Colour(50, 200, 80),
+    "complete": wx.Colour(100, 180, 255),
+    "failed": wx.Colour(220, 50, 50),
+    "cancelled": wx.Colour(180, 130, 50),
+    "pending_stop": wx.Colour(220, 200, 50),
+    "queued": wx.Colour(180, 180, 180),
+    "pending": wx.Colour(180, 180, 180),
 }
 
 # Columns for the main scan table
 SCAN_COLUMNS = [
-    ("Scan ID",       180),
-    ("Status",        110),
-    ("Targets",        70),
-    ("Initiated By",  160),
-    ("Started",       160),
-    ("Findings",       80),
-    ("Description",   220),
+    ("Scan ID", 180),
+    ("Status", 110),
+    ("Targets", 70),
+    ("Initiated By", 160),
+    ("Started", 160),
+    ("Findings", 80),
+    ("Description", 220),
 ]
 
 # Columns for the per-host table in the detail panel
 HOST_COLUMNS = [
-    ("Host ID",  180),
-    ("Status",   110),
-    ("Scanned",   80),
+    ("Host ID", 180),
+    ("Status", 110),
+    ("Scanned", 80),
     ("Malicious", 80),
-    ("Quarant.",  80),
-    ("Started",  155),
+    ("Quarant.", 80),
+    ("Started", 155),
 ]
 
 
@@ -235,7 +237,7 @@ class ODSClient:
         self.status: str = "disconnected"
         self.error: str = ""
 
-    def connect(self, client_id: str = "", client_secret: str = "") -> bool: # nosec - Bandit FP
+    def connect(self, client_id: str = "", client_secret: str = "") -> bool:  # nosec - Bandit FP
         """Authenticate against the Falcon API and return True on success.
 
         *client_id* and *client_secret* override the FALCON_CLIENT_ID /
@@ -1048,7 +1050,7 @@ class ODSManagerFrame(wx.Frame):
         self._show_new_scan_dialog(available_hosts, prefill=None)
 
     def _show_new_scan_dialog(self, available_hosts: list[dict], prefill: dict | None):
-        """Internal: display the New Scan dialog; re-opens with prefill if scan fails."""
+        """Display the New Scan dialog; re-opens with prefill if scan fails."""
         dlg = NewScanDialog(self, available_hosts=available_hosts, prefill=prefill)
         if dlg.ShowModal() != wx.ID_OK:
             dlg.Destroy()

--- a/samples/rtr/rtr-replay/rtr_replay.py
+++ b/samples/rtr/rtr-replay/rtr_replay.py
@@ -30,7 +30,8 @@ Modified by: jshcodes@CrowdStrike
 """
 import os
 from datetime import datetime
-from argparse import ArgumentParser, RawTextHelpFormatter
+from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
+from typing import Optional
 
 from falconpy import RealTimeResponseAudit  # pylint: disable=import-error
 
@@ -91,7 +92,7 @@ _DEMO_SESSION = {
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 
-def consume_arguments() -> object:
+def consume_arguments() -> Namespace:
     """Consume provided command line arguments."""
     parser = ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
 
@@ -160,7 +161,7 @@ def format_datetime(iso_str: str) -> str:
         return iso_str
 
 
-def format_duration(seconds: float) -> str:
+def format_duration(seconds: Optional[float]) -> str:
     """Format a float duration in seconds as a human-readable string."""
     if seconds is None:
         return "—"
@@ -202,7 +203,7 @@ def print_command_log(logs: list):
     ordered = sorted(logs, key=lambda e: (e.get("created_at") or "", e.get("id") or 0))
 
     print(f"  Commands ({len(ordered)}):")
-    print("  " + "-" * 68)
+    print("  " + "-" * 70)
     for entry in ordered:
         timestamp = format_datetime(entry.get("created_at"))
         cwd = entry.get("current_directory") or "—"
@@ -243,7 +244,7 @@ def call_audit_sessions(sdk: RealTimeResponseAudit,
     if fql_filter:
         kwargs["filter"] = fql_filter
     if limit is not None:
-        kwargs["limit"] = str(limit)
+        kwargs["limit"] = limit
     if offset is not None:
         kwargs["offset"] = str(offset)
 
@@ -360,7 +361,7 @@ if __name__ == "__main__":
     args = consume_arguments()
 
     # Demo mode: no credentials required.
-    if args.demo or (not args.falcon_client_id and not args.falcon_client_secret):
+    if args.demo:
         run_demo()
         raise SystemExit(0)
 

--- a/samples/rtr/rtr-replay/rtr_replay_gui.py
+++ b/samples/rtr/rtr-replay/rtr_replay_gui.py
@@ -83,7 +83,7 @@ Ridiculous GUI by: jshcodes@CrowdStrike
 import math
 import os
 import sys
-from argparse import ArgumentParser, RawTextHelpFormatter
+from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 from datetime import datetime
 
 # pylint: disable=import-error
@@ -169,8 +169,6 @@ def _asset_path(filename: str) -> str:
 _LOGO_PATH = _asset_path("cs-logo-red.png")
 # FalconPy logo displayed in the upper-right of the credential panel.
 _FALCONPY_LOGO_PATH = _asset_path("falconpy-logo.png")
-# Punk spider easter-egg image.
-_PUNK_SPIDER_PATH = _asset_path("punk-spider.png")
 
 # Human-readable short labels for each CrowdStrike cloud region.
 # The dict maps BaseURL enum names (e.g. "US1") to display strings
@@ -299,7 +297,7 @@ _DEMO_SESSIONS = [
 # ── Argument parsing ─────────────────────────────────────────────────────────
 
 
-def consume_arguments() -> object:
+def consume_arguments() -> Namespace:
     """Parse and return command-line arguments for the GUI launcher.
 
     All arguments are optional — the window can be opened with no
@@ -719,6 +717,11 @@ class PrefetchWorker(QThread):
         """
         cursor = self._start_cursor
         page = self._start_page
+        sdk = RealTimeResponseAudit(
+            client_id=self._client_id,
+            client_secret=self._client_secret,
+            base_url=self._base_url,
+        )
 
         while cursor and not self._stop:
             # ── Pause gate ───────────────────────────────────────────
@@ -736,11 +739,6 @@ class PrefetchWorker(QThread):
 
             # ── API call ─────────────────────────────────────────────
             try:
-                sdk = RealTimeResponseAudit(
-                    client_id=self._client_id,
-                    client_secret=self._client_secret,
-                    base_url=self._base_url,
-                )
                 kwargs = {
                     "with_command_info": True,
                     "limit": str(self._page_size),
@@ -854,24 +852,6 @@ def build_session_model(sessions: list) -> QStandardItemModel:
 # ── Main window ──────────────────────────────────────────────────────────────
 
 
-class _ClickableLabel(QLabel):
-    """QLabel that emits a ``ctrl_shift_clicked`` signal on Ctrl+Shift+click.
-
-    Used for the FalconPy logo to trigger the easter-egg dialog without
-    affecting normal label behaviour for plain clicks.
-    """
-
-    ctrl_shift_clicked = Signal()
-
-    def mousePressEvent(self, event):  # pylint: disable=invalid-name
-        """Emit ctrl_shift_clicked when both Ctrl and Shift are held."""
-        mods = event.modifiers()
-        if (mods & Qt.ControlModifier) and (mods & Qt.ShiftModifier):
-            self.ctrl_shift_clicked.emit()
-        else:
-            super().mousePressEvent(event)
-
-
 class _SmartDateEdit(QDateEdit):
     """QDateEdit that opens its calendar popup at the current month.
 
@@ -932,23 +912,6 @@ class _SmartDateEdit(QDateEdit):
             today = QDate.currentDate()
             watched.setCurrentPage(today.year(), today.month())
         return False
-
-
-class SessionFilterProxy(QSortFilterProxyModel):
-    """QSortFilterProxyModel with case-insensitive substring matching.
-
-    Wraps the built-in ``setFilterFixedString`` / ``setFilterKeyColumn``
-    behaviour with a convenient subclass so future filter extensions have
-    a natural home.
-
-    Usage::
-
-        proxy = SessionFilterProxy()
-        proxy.setSourceModel(source_model)
-        proxy.setFilterKeyColumn(-1)          # all-column text filter
-        proxy.setFilterCaseSensitivity(Qt.CaseInsensitive)
-        proxy.setFilterFixedString("WIN")
-    """
 
 
 class RTRReplayWindow(QMainWindow):  # pylint: disable=too-few-public-methods
@@ -1294,11 +1257,10 @@ class RTRReplayWindow(QMainWindow):  # pylint: disable=too-few-public-methods
             fp_scaled = fp_big.scaledToHeight(
                 80, Qt.SmoothTransformation
             )
-            fp_label = _ClickableLabel(self)
+            fp_label = QLabel(self)
             fp_label.setPixmap(fp_scaled)
             fp_label.setAlignment(Qt.AlignVCenter | Qt.AlignHCenter)
             fp_label.setContentsMargins(0, 0, 0, 0)
-            fp_label.ctrl_shift_clicked.connect(self._show_easter_egg)
 
             # Clickable "Source code" hyperlink.
             link_label = QLabel(
@@ -2356,45 +2318,6 @@ class RTRReplayWindow(QMainWindow):  # pylint: disable=too-few-public-methods
             f"Copied command log ({lines} line(s)) to clipboard."
         )
 
-    def _show_easter_egg(self):
-        """Display the easter-egg dialog (Ctrl+Shift+click on FalconPy logo).
-
-        Shows the CrowdStrike logo, the punk spider image, and the text
-        "WE STOP BREACHES" in a simple modal dialog.
-        """
-        dlg = QDialog(self)
-        dlg.setWindowTitle("CrowdStrike")
-        layout = QVBoxLayout(dlg)
-        layout.setContentsMargins(24, 24, 24, 24)
-        layout.setSpacing(12)
-
-        if os.path.exists(_LOGO_PATH):
-            cs_pixmap = QPixmap(_LOGO_PATH)
-            cs_label = QLabel()
-            cs_label.setPixmap(
-                cs_pixmap.scaledToHeight(80, Qt.SmoothTransformation)
-            )
-            cs_label.setAlignment(Qt.AlignHCenter)
-            layout.addWidget(cs_label)
-
-        if os.path.exists(_PUNK_SPIDER_PATH):
-            spider_pixmap = QPixmap(_PUNK_SPIDER_PATH)
-            spider_label = QLabel()
-            spider_label.setPixmap(
-                spider_pixmap.scaledToHeight(180, Qt.SmoothTransformation)
-            )
-            spider_label.setAlignment(Qt.AlignHCenter)
-            layout.addWidget(spider_label)
-
-        tagline = QLabel("WE STOP BREACHES")
-        tagline.setAlignment(Qt.AlignHCenter)
-        tagline.setStyleSheet(
-            "font-size: 18pt; font-weight: bold; color: #ec0000;"
-        )
-        layout.addWidget(tagline)
-
-        dlg.exec()
-
     def _on_session_selected(self, selected, _deselected):
         """Populate the replay panel when the user selects a table row.
 
@@ -2457,9 +2380,10 @@ class RTRReplayWindow(QMainWindow):  # pylint: disable=too-few-public-methods
                 else:
                     worker.quit()
                 if not worker.wait(500):
-                    # Graceful exit timed out — force-kill the OS thread.
-                    worker.terminate()
-                    worker.wait()
+                    # Worker did not exit within timeout. Calling terminate() here
+                    # would send pthread_cancel into urllib3/SSL, corrupting the GIL.
+                    # Accept the leak — the OS will reclaim the thread on process exit.
+                    pass
 
         super().closeEvent(event)
 
@@ -2541,8 +2465,8 @@ class RTRReplayWindow(QMainWindow):  # pylint: disable=too-few-public-methods
         """
         source_model = build_session_model(sessions)
 
-        # Wrap in SessionFilterProxy to enable text filter across all columns.
-        self._proxy_model = SessionFilterProxy()
+        # Wrap in QSortFilterProxyModel to enable text filter across all columns.
+        self._proxy_model = QSortFilterProxyModel()
         self._proxy_model.setSourceModel(source_model)
         # filterKeyColumn(-1) searches across all columns simultaneously.
         self._proxy_model.setFilterKeyColumn(-1)

--- a/samples/rtr/rtr-replay/rtr_replay_gui.py
+++ b/samples/rtr/rtr-replay/rtr_replay_gui.py
@@ -76,7 +76,7 @@ Architecture overview
 Created by: Manjula Wickramasuriya (@Manjula101) - Enterprise Security Lab
 Ridiculous GUI by: jshcodes@CrowdStrike
 """
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,unsupported-binary-operation
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 # pylint: disable=too-many-locals,too-few-public-methods
 # pylint: disable=too-many-instance-attributes,too-many-statements
@@ -86,7 +86,7 @@ import sys
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 from datetime import datetime
 
-# pylint: disable=import-error
+# pylint: disable=import-error,no-name-in-module
 from PySide6.QtCore import (
     Qt, QDate, QEvent, QThread, Signal, QSortFilterProxyModel,
     QMutex, QMutexLocker, QWaitCondition,
@@ -96,7 +96,6 @@ from PySide6.QtWidgets import (
     QApplication,
     QComboBox,
     QDateEdit,
-    QDialog,
     QFrame,
     QGroupBox,
     QHBoxLayout,
@@ -119,7 +118,7 @@ from PySide6.QtWidgets import (
 from falconpy import (
     BaseURL, RealTimeResponseAudit, version as _falconpy_version
 )
-# pylint: enable=import-error
+# pylint: enable=import-error,no-name-in-module
 
 # ── Constants ────────────────────────────────────────────────────────────────
 

--- a/samples/spotlight/spotlight_vuln_dashboard/spotlight_vuln_dashboard.py
+++ b/samples/spotlight/spotlight_vuln_dashboard/spotlight_vuln_dashboard.py
@@ -271,21 +271,12 @@ class FalconDataLayer:
             ValueError: Credentials rejected by the API (HTTP 401).
             RuntimeError: Probe failed for a non-authentication reason.
         """
-        if region == "auto":
-            base_url = "https://api.crowdstrike.com"
-        else:
-            base_url = f"https://api.{region}.crowdstrike.com"
-
         self._spotlight = SpotlightVulnerabilities(
             client_id=client_id,
             client_secret=client_secret,
-            base_url=base_url,
+            base_url=region,
         )
-        self._hosts = Hosts(
-            client_id=client_id,
-            client_secret=client_secret,
-            base_url=base_url,
-        )
+        self._hosts = Hosts(auth_object=self._spotlight)
 
         # Fail fast: verify credentials before the caller builds any UI.
         self._validate_credentials()
@@ -471,7 +462,6 @@ class FalconDataLayer:
             # request with the *current* page's parse/notify work, which is the
             # maximum pipeline depth achievable under cursor pagination.
             pending: Future = executor.submit(_fetch, None)
-            _after_token: Optional[str] = None
 
             while True:
                 # Poll with a short timeout so a stop request is honoured within
@@ -512,7 +502,8 @@ class FalconDataLayer:
                 if not next_after:
                     break
 
-                _after_token = next_after  # noqa: F841  (kept for clarity)
+                # next_after is consumed by the next loop iteration via `pending`.
+                _ = next_after
 
                 # Post-processing stop check: avoid submitting the just-queued
                 # next fetch if a stop was requested while we were processing.
@@ -615,74 +606,6 @@ def normalise_cve_id(raw: str) -> str:
 # ---------------------------------------------------------------------------
 
 _FQL_INJECTION_RE = re.compile(r"['\"]")
-
-
-def _build_fql(
-    *,
-    status: str = "open",
-    cve_id: str = "",
-    severity: str = "",
-    cvss_min: float = 0.0,
-    cvss_max: float = 10.0,
-    created_after: str = "",
-    created_before: str = "",
-) -> str:
-    """Build a Spotlight FQL filter string from UI widget values.
-
-    All string inputs are sanitised: single-quotes and double-quotes are
-    stripped to prevent FQL injection.
-
-    Args:
-        status: Remediation status — ``"open"``, ``"closed"``, or ``""``
-            for no status filter.
-        cve_id: CVE ID fragment to match (partial allowed); already
-            normalised by ``normalise_cve_id()`` before being passed here.
-        severity: Severity level — ``"CRITICAL"``, ``"HIGH"``, etc., or
-            ``""`` for no severity filter.
-        cvss_min: Minimum CVSS score (inclusive).
-        cvss_max: Maximum CVSS score (inclusive).
-        created_after: ISO date string ``YYYY-MM-DD`` for lower bound on
-            ``created_timestamp``, or ``""`` to omit.
-        created_before: ISO date string ``YYYY-MM-DD`` for upper bound, or
-            ``""`` to omit.
-
-    Returns:
-        FQL filter string, e.g.
-        ``"status:'open'+cve.id:'CVE-2024-*'+cve.base_score:>=7.0"``.
-        Returns ``""`` when no filters are active (Spotlight returns all
-        records).
-    """
-
-    def _sanitise(s: str) -> str:
-        return _FQL_INJECTION_RE.sub("", s)
-
-    parts: List[str] = []
-
-    if status:
-        parts.append(f"status:'{_sanitise(status)}'")
-
-    if cve_id:
-        safe_cve = _sanitise(cve_id)
-        # Append wildcard to support partial prefix matches (e.g. CVE-2024-*).
-        if not safe_cve.endswith("*"):
-            safe_cve += "*"
-        parts.append(f"cve.id:'{safe_cve}'")
-
-    if severity:
-        parts.append(f"cve.severity:'{_sanitise(severity)}'")
-
-    # CVSS range — only emit when non-default.
-    if cvss_min > 0.0:
-        parts.append(f"cve.base_score:>={cvss_min:.1f}")
-    if cvss_max < 10.0:
-        parts.append(f"cve.base_score:<={cvss_max:.1f}")
-
-    if created_after:
-        parts.append(f"created_timestamp:>'{_sanitise(created_after)}T00:00:00Z'")
-    if created_before:
-        parts.append(f"created_timestamp:<'{_sanitise(created_before)}T23:59:59Z'")
-
-    return "+".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -1707,6 +1630,8 @@ class DashboardWindow(QMainWindow):
                 item = QTableWidgetItem(getattr(rec, attr))
                 item.setForeground(brush)
                 item.setFlags(item.flags() & ~Qt.ItemIsEditable)
+                if col == 0:
+                    item.setData(Qt.ItemDataRole.UserRole, rec)
                 self._table.setItem(row, col, item)
 
         self._table.setSortingEnabled(True)
@@ -1718,12 +1643,15 @@ class DashboardWindow(QMainWindow):
     def _on_cell_double_clicked(self, row: int, _col: int) -> None:
         """Open a CVE detail dialog for the selected row.
 
-        The row index maps directly into ``_filtered_records`` — the same list
-        that ``_populate_table`` iterated over to build the current table view.
+        Uses the VulnRecord stored in UserRole on column 0 so the lookup
+        remains correct after the user sorts the table.
         """
-        if row < 0 or row >= len(self._filtered_records):
+        item = self._table.item(row, 0)
+        if not item:
             return
-        rec = self._filtered_records[row]
+        rec = item.data(Qt.ItemDataRole.UserRole)
+        if not rec:
+            return
         dlg = CveDetailDialog(rec, parent=self)
         dlg.show()  # Non-modal — user can open multiple dialogs.
 

--- a/samples/spotlight/spotlight_vuln_dashboard/spotlight_vuln_dashboard.py
+++ b/samples/spotlight/spotlight_vuln_dashboard/spotlight_vuln_dashboard.py
@@ -84,6 +84,9 @@ Environment variables (optional — skips credential dialog)
 
 CLI arguments take precedence over environment variables.
 """
+# pylint: disable=too-many-lines,too-many-instance-attributes,too-many-statements
+# pylint: disable=too-many-arguments,too-few-public-methods,attribute-defined-outside-init
+# pylint: disable=invalid-name,unsupported-binary-operation
 
 import argparse
 import csv
@@ -93,10 +96,10 @@ import threading
 import time
 from concurrent.futures import CancelledError, Future, ThreadPoolExecutor
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import datetime
 from typing import Dict, List, Optional
 
-# pylint: disable=import-error
+# pylint: disable=import-error,no-name-in-module
 from PySide6.QtCore import QDate, Qt, QThread, QTimer, QUrl, Signal
 from PySide6.QtGui import QBrush, QColor, QDesktopServices, QPixmap
 from PySide6.QtWidgets import (
@@ -126,7 +129,7 @@ from PySide6.QtWidgets import (
 )
 
 from falconpy import Hosts, SpotlightVulnerabilities  # pylint: disable=import-error
-# pylint: enable=import-error
+# pylint: enable=import-error,no-name-in-module
 
 # ---------------------------------------------------------------------------
 # Optional matplotlib dependency — chart is hidden gracefully when absent.
@@ -366,7 +369,7 @@ class FalconDataLayer:
         """
         return self.get_vulnerabilities_paged(on_page=lambda *_: None)
 
-    def get_vulnerabilities_paged(
+    def get_vulnerabilities_paged(  # noqa: C901
         self,
         on_page,
         stop_event: Optional[threading.Event] = None,
@@ -541,7 +544,7 @@ class FalconDataLayer:
         host_map: Dict[str, dict] = {}
 
         for i in range(0, len(host_ids), HOST_BATCH_SIZE):
-            batch = host_ids[i : i + HOST_BATCH_SIZE]
+            batch = host_ids[i: i + HOST_BATCH_SIZE]
             try:
                 resp = self._call_with_retry(
                     self._hosts.get_device_details, ids=batch
@@ -740,6 +743,7 @@ class CredentialDialog(QDialog):
     """
 
     def __init__(self, parent=None, region_default: str = "auto") -> None:
+        """Build the credential dialog with optional region default."""
         super().__init__(parent)
         self.setWindowTitle("Falcon API Credentials")
         self.setModal(True)
@@ -1539,7 +1543,7 @@ class DashboardWindow(QMainWindow):
             return False
         if hostname_search and hostname_search not in rec.hostname.upper():
             return False
-        if os_filter != "All" and rec.os_platform != os_filter:
+        if os_filter not in ("All", rec.os_platform):
             return False
         return True
 

--- a/samples/tailored_intelligence/tailored_intel_browser/tailored_intel_browser.py
+++ b/samples/tailored_intelligence/tailored_intel_browser/tailored_intel_browser.py
@@ -77,9 +77,10 @@ Required API scope
 import argparse
 import json
 import os
+import re
 import sys
 import threading
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 # ---------------------------------------------------------------------------
@@ -90,23 +91,6 @@ from typing import Optional
 # now, store the values in module-level variables, and restore argv minus our
 # flags so Kivy never sees -k/-s.
 # ---------------------------------------------------------------------------
-
-def _scrub_credentials_from_argv() -> tuple:
-    """Remove -k/-s from sys.argv before Kivy imports consume them.
-
-    Returns (client_id, client_secret) extracted from sys.argv, or ("", "")
-    if not present.  sys.argv is modified in-place to strip the flags.
-    """
-    _parser = argparse.ArgumentParser(description=__doc__,
-                                      formatter_class=argparse.RawDescriptionHelpFormatter)
-    _parser.add_argument("-k", dest="client_id", default="", metavar="CLIENT_ID")
-    _parser.add_argument("-s", dest="client_secret", default="", metavar="CLIENT_SECRET")
-    _args, _remainder = _parser.parse_known_args()
-    sys.argv = sys.argv[:1] + _remainder
-    return _args.client_id, _args.client_secret
-
-
-_PRE_IMPORT_CLIENT_ID, _PRE_IMPORT_CLIENT_SECRET = _scrub_credentials_from_argv()
 
 os.environ["KIVY_NO_ARGS"] = "1"
 
@@ -812,7 +796,7 @@ class EventRecord:
             or ""
         )
         # Full raw dict for the detail view.
-        self._raw: dict = raw
+        self._raw: dict = dict(raw)
 
     def confidence_color(self) -> list:
         """Return an RGBA list colour-coded by confidence string."""
@@ -844,7 +828,7 @@ class RuleRecord:
             self.enabled: Optional[bool] = None
         else:
             self.enabled = bool(enabled_raw)
-        self._raw: dict = raw
+        self._raw: dict = dict(raw)
 
     def status_text(self) -> str:
         """Return a human-readable status string."""
@@ -875,7 +859,7 @@ def _format_ts(raw_ts: str) -> str:
             ts_val = float(raw_ts)
             if ts_val > 1e10:
                 ts_val /= 1000  # milliseconds → seconds
-            dt = datetime.utcfromtimestamp(ts_val)
+            dt = datetime.fromtimestamp(ts_val, tz=timezone.utc)
             return dt.strftime("%Y-%m-%d %H:%M")
         # ISO8601 string; strip trailing Z or +offset.
         clean = str(raw_ts)[:19].replace("T", " ")
@@ -924,85 +908,18 @@ def _format_raw(raw: dict, max_entries: int = 30) -> str:
 
 
 def _parse_body_flexible(text: str) -> Optional[dict]:
-    """Attempt to parse *text* as structured data, tolerating common non-JSON formats.
-
-    Tries in order:
-      1. Standard JSON (json.loads).
-      2. Lua-table notation — ``["key"] = value`` — converted to JSON-like form.
-      3. Regex heuristic: extract ``key = value`` or ``"key": value`` pairs.
-
-    Returns a dict if any method succeeds, or ``None`` if the text is not
-    parseable as a key-value structure.  Callers should treat the raw string as
-    plain text when ``None`` is returned.
-    """
-    import re  # pylint: disable=import-outside-toplevel
-
+    """Attempt to parse *text* as a JSON object. Returns None if not parseable."""
     if not text:
         return None
     stripped = text.strip()
-
-    # ── Pass 1: standard JSON ────────────────────────────────────────────────
     if stripped[:1] in ("{", "[", '"'):
         try:
             result = json.loads(stripped)
             if isinstance(result, dict):
                 return result
-            return None  # arrays / scalars handled by callers directly
         except (json.JSONDecodeError, ValueError):
             pass
-
-    # Only attempt further parsing if the text looks like a table/struct.
-    if stripped[:1] != "{":
-        return None
-
-    # ── Pass 2: Lua-table / annotated-JSON heuristic ─────────────────────────
-    # Lua tables use  ["key"] = value  instead of  "key": value.
-    # Also handles JS-style  key: value  (unquoted keys).
-    # Steps:
-    #   a) ["key"] = value  →  "key": value
-    #   b) key = value  (bare identifier)  →  "key": value
-    #   c) Remove trailing commas before } or ]
-    #   d) Convert Lua true/false/nil → JSON true/false/null
-    lua = stripped
-    # a) ["key"] = expr  →  "key": expr
-    lua = re.sub(r'\["([^"]+)"\]\s*=\s*', r'"\1": ', lua)
-    # b) bare_key = expr  (only if looks like identifier, not already a string)
-    lua = re.sub(r'(?<!["\w])([A-Za-z_][A-Za-z0-9_.]*)\s*=\s*(?!")', r'"\1": ', lua)
-    # c) trailing commas before closing brackets
-    lua = re.sub(r',\s*([}\]])', r'\1', lua)
-    # d) Lua literals
-    lua = re.sub(r'\btrue\b', 'true', lua)
-    lua = re.sub(r'\bfalse\b', 'false', lua)
-    lua = re.sub(r'\bnil\b', 'null', lua)
-
-    try:
-        result = json.loads(lua)
-        if isinstance(result, dict):
-            return result
-    except (json.JSONDecodeError, ValueError):
-        pass
-
-    # ── Pass 3: pure regex extraction ────────────────────────────────────────
-    # Extract all  "key": value  or  key = value  pairs from the raw text.
-    pairs: dict = {}
-    # Pattern A: quoted key, colon, value (JSON-like)
-    for m in re.finditer(r'"([^"]+)"\s*[:=]\s*("(?:[^"\\]|\\.)*"|\d[\d.]*|true|false|null|\[[^\]]*\])', stripped):
-        k = m.group(1)
-        v_raw = m.group(2)
-        try:
-            pairs[k] = json.loads(v_raw)
-        except (json.JSONDecodeError, ValueError):
-            pairs[k] = v_raw.strip('"')
-    # Pattern B: bare key = value (Lua-style, e.g. motd.enable = true)
-    for m in re.finditer(r'([A-Za-z_][A-Za-z0-9_.]*)\s*=\s*("(?:[^"\\]|\\.)*"|\d[\d.]*|true|false|nil)', stripped):
-        k = m.group(1)
-        v_raw = m.group(2).replace("nil", "null")
-        try:
-            pairs[k] = json.loads(v_raw)
-        except (json.JSONDecodeError, ValueError):
-            pairs[k] = v_raw.strip('"')
-
-    return pairs if pairs else None
+    return None
 
 
 def _extract_headline_from_body(body: str) -> str:
@@ -1466,10 +1383,6 @@ class TabBar(BoxLayout):
     """Horizontal tab bar for switching between Events and Rules views."""
 
 
-class TabButton(Widget):
-    """Single tab button (inactive state)."""
-
-
 class EventCard(RecycleDataViewBehavior, BoxLayout):
     """One row in the event RecycleView — displays type, headline, confidence."""
 
@@ -1816,7 +1729,7 @@ class TailoredIntelBrowserApp(App):
         if delta is None:
             return ""  # 'all' — no filter
 
-        since = (datetime.utcnow() - delta).strftime("%Y-%m-%dT%H:%M:%SZ")
+        since = (datetime.now(timezone.utc) - delta).strftime("%Y-%m-%dT%H:%M:%SZ")
         return f"created_date:>='{since}'"
 
     # ------------------------------------------------------------------
@@ -2105,15 +2018,19 @@ class TailoredIntelBrowserApp(App):
 # ---------------------------------------------------------------------------
 
 def main():
-    """Launch the Tailored Intel Browser application.
-
-    Credentials from -k/-s are scraped from sys.argv at module import time
-    (before Kivy can consume -k/-s as its own fake-fullscreen / save flags)
-    and stored in _PRE_IMPORT_CLIENT_ID / _PRE_IMPORT_CLIENT_SECRET.
-    """
+    """Launch the Tailored Intel Browser application."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("-k", dest="client_id", default="", metavar="CLIENT_ID",
+                        help="Falcon API client ID (overrides FALCON_CLIENT_ID env var)")
+    parser.add_argument("-s", dest="client_secret", default="", metavar="CLIENT_SECRET",
+                        help="Falcon API client secret (overrides FALCON_CLIENT_SECRET env var)")
+    args = parser.parse_args()
     TailoredIntelBrowserApp(
-        client_id=_PRE_IMPORT_CLIENT_ID,
-        client_secret=_PRE_IMPORT_CLIENT_SECRET,
+        client_id=args.client_id,
+        client_secret=args.client_secret,
     ).run()
 
 

--- a/samples/tailored_intelligence/tailored_intel_browser/tailored_intel_browser.py
+++ b/samples/tailored_intelligence/tailored_intel_browser/tailored_intel_browser.py
@@ -73,45 +73,34 @@ Required API scope
 # pylint: disable=too-many-locals,too-many-statements
 # pylint: disable=too-many-instance-attributes,too-many-branches
 # pylint: disable=wrong-import-position,wrong-import-order,import-error
+# pylint: disable=too-few-public-methods,attribute-defined-outside-init,protected-access
+# pylint: disable=too-many-return-statements
 
 import argparse
 import json
 import os
-import re
-import sys
 import threading
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-# ---------------------------------------------------------------------------
-# PRE-IMPORT argv scrubbing — MUST happen before any Kivy import.
-#
-# Kivy processes sys.argv at import time and treats -k (fake-fullscreen) and
-# -s (save) as its own flags.  Scrub our credential flags out of sys.argv
-# now, store the values in module-level variables, and restore argv minus our
-# flags so Kivy never sees -k/-s.
-# ---------------------------------------------------------------------------
-
+# KIVY_NO_ARGS must be set before any Kivy import to prevent Kivy from
+# consuming -k/-s as its own fake-fullscreen/save flags.
 os.environ["KIVY_NO_ARGS"] = "1"
 
-from kivy.app import App
-from kivy.clock import Clock
-from kivy.lang import Builder
-from kivy.properties import (
-    BooleanProperty,
+from kivy.app import App  # noqa: E402
+from kivy.clock import Clock  # noqa: E402
+from kivy.lang import Builder  # noqa: E402
+from kivy.properties import (  # noqa: E402
     ListProperty,
     NumericProperty,
-    ObjectProperty,
     StringProperty,
 )
-from kivy.uix.boxlayout import BoxLayout
-from kivy.uix.floatlayout import FloatLayout
-from kivy.uix.label import Label
-from kivy.uix.recycleview import RecycleView
-from kivy.uix.recycleview.views import RecycleDataViewBehavior
-from kivy.uix.screenmanager import Screen, ScreenManager
-from kivy.uix.widget import Widget
-from falconpy import TailoredIntelligence
+from kivy.uix.boxlayout import BoxLayout  # noqa: E402
+from kivy.uix.floatlayout import FloatLayout  # noqa: E402
+from kivy.uix.recycleview import RecycleView  # noqa: E402
+from kivy.uix.recycleview.views import RecycleDataViewBehavior  # noqa: E402
+from kivy.uix.screenmanager import Screen, ScreenManager  # noqa: E402
+from falconpy import TailoredIntelligence  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Kivy KV layout definitions
@@ -744,6 +733,7 @@ KV = r"""
 # Data models
 # ---------------------------------------------------------------------------
 
+
 class EventRecord:
     """Holds data for a single TailoredIntelligence event."""
 
@@ -1230,7 +1220,7 @@ class TailoredIntelClient:
     def connect(
         self,
         client_id_override: str = "",
-        client_secret_override: str = "", # nosec - Bandit FP
+        client_secret_override: str = "",  # nosec - Bandit FP
     ) -> bool:
         """Authenticate using provided credentials or env vars.
 
@@ -1313,7 +1303,7 @@ class TailoredIntelClient:
         # Fetch event entities in batches.
         records: list[EventRecord] = []
         for i in range(0, len(all_ids), self._BATCH_SIZE):
-            batch = all_ids[i : i + self._BATCH_SIZE]
+            batch = all_ids[i: i + self._BATCH_SIZE]
             resp = self._sdk.get_event_entities(ids=batch)
             if resp.get("status_code", 0) not in (200, 201):
                 continue
@@ -1357,7 +1347,7 @@ class TailoredIntelClient:
 
         records: list[RuleRecord] = []
         for i in range(0, len(all_ids), self._BATCH_SIZE):
-            batch = all_ids[i : i + self._BATCH_SIZE]
+            batch = all_ids[i: i + self._BATCH_SIZE]
             resp = self._sdk.get_rule_entities(ids=batch)
             if resp.get("status_code", 0) not in (200, 201):
                 continue
@@ -1397,7 +1387,7 @@ class EventCard(RecycleDataViewBehavior, BoxLayout):
     confidence_color = ListProperty([0.6, 0.6, 0.6, 1])
 
     def refresh_view_attrs(self, rv, index, data):
-        """Called by RecycleView to bind data to this widget instance."""
+        """Bind data to this widget instance (called by RecycleView)."""
         self.index = index
         return super().refresh_view_attrs(rv, index, data)
 
@@ -1432,7 +1422,7 @@ class RuleCard(RecycleDataViewBehavior, BoxLayout):
     rule_status_color = ListProperty([0.6, 0.6, 0.6, 1])
 
     def refresh_view_attrs(self, rv, index, data):
-        """Called by RecycleView to bind data to this widget instance."""
+        """Bind data to this widget instance (called by RecycleView)."""
         self.index = index
         return super().refresh_view_attrs(rv, index, data)
 
@@ -1514,7 +1504,7 @@ class TailoredIntelBrowserApp(App):
     # Current tab ('events' or 'rules').
     _active_tab = "events"
 
-    def __init__(self, client_id: str = "", client_secret: str = "", **kwargs): # nosec - Bandit FP
+    def __init__(self, client_id: str = "", client_secret: str = "", **kwargs):  # nosec - Bandit FP
         """Initialise the app and its supporting components.
 
         *client_id* and *client_secret* may be provided from CLI args.  When
@@ -1620,8 +1610,8 @@ class TailoredIntelBrowserApp(App):
 
     def _make_tab_button(self, text: str, active: bool):
         """Create a styled tab Button widget."""
-        from kivy.uix.button import Button
-        from kivy.metrics import dp
+        from kivy.uix.button import Button  # pylint: disable=import-outside-toplevel
+        from kivy.metrics import dp  # pylint: disable=import-outside-toplevel
         btn = Button(
             text=text,
             size_hint_x=None,
@@ -1636,7 +1626,7 @@ class TailoredIntelBrowserApp(App):
         return btn
 
     def on_start(self):
-        """Called after build() — authenticate in background then load data."""
+        """Authenticate in background then load data after build() completes."""
         self._set_status("connecting")
 
         def _auth_worker():
@@ -1649,7 +1639,7 @@ class TailoredIntelBrowserApp(App):
         threading.Thread(target=_auth_worker, daemon=True).start()
 
     def _on_connect_done(self, ok: bool):
-        """Called on main thread after background auth completes."""
+        """Handle auth completion on the main thread after background auth."""
         if ok:
             self._set_status("connected")
             self._load_data()
@@ -1795,7 +1785,7 @@ class TailoredIntelBrowserApp(App):
     # ------------------------------------------------------------------
 
     def _on_events_loaded(self, _dt):
-        """Called on the main thread after event loading completes."""
+        """Populate the event feed on the main thread after loading completes."""
         self._show_loading(False)
         with self.state.lock:
             events = list(self.state.events)
@@ -1811,7 +1801,7 @@ class TailoredIntelBrowserApp(App):
         self._rebuild_events_list(events)
 
     def _on_rules_loaded(self, _dt):
-        """Called on the main thread after rule loading completes."""
+        """Populate the rules list on the main thread after loading completes."""
         with self.state.lock:
             rules = list(self.state.rules)
         self._rebuild_rules_list(rules)

--- a/samples/zero_trust_assessment/zta_score_viewer/zta_score_viewer.py
+++ b/samples/zero_trust_assessment/zta_score_viewer/zta_score_viewer.py
@@ -63,6 +63,7 @@ Required API scope
 # pylint: disable=too-many-lines
 # pylint: disable=too-many-locals,too-many-statements
 # pylint: disable=too-many-instance-attributes,too-many-branches
+# pylint: disable=too-few-public-methods,import-error
 
 import argparse
 import json
@@ -93,7 +94,7 @@ PLATFORM_NAMES = {
 }
 
 # Score distribution buckets: [0-9], [10-19], …, [90-100]
-BUCKET_LABELS = [f"{i*10}-{i*10+9}" if i < 10 else "100" for i in range(11)]
+BUCKET_LABELS = [f"{i * 10}-{i * 10 + 9}" if i < 10 else "100" for i in range(11)]
 NUM_BUCKETS = 11  # 0-9 through 100 (100 is its own bucket)
 
 AUTO_REFRESH_OPTIONS = ["Off", "30s", "1m", "5m"]
@@ -105,9 +106,9 @@ DEFAULT_PAGE_SIZE = 50
 # Severity colour bands (R, G, B, A) mapped to score ranges
 SCORE_COLOURS = {
     "critical": (220, 50, 50, 255),   # 0–39
-    "high":     (220, 130, 50, 255),  # 40–59
-    "medium":   (220, 200, 50, 255),  # 60–79
-    "good":     (50, 180, 80, 255),   # 80–100
+    "high": (220, 130, 50, 255),  # 40–59
+    "medium": (220, 200, 50, 255),  # 60–79
+    "good": (50, 180, 80, 255),   # 80–100
 }
 
 
@@ -299,7 +300,7 @@ class ZTAClient:
             try:
                 resp = self._hosts_sdk.get_device_details_v2(ids=batch)
             except Exception:  # pylint: disable=broad-except
-                continue # nosec - Allow silent 404 failure
+                continue  # nosec - Allow silent 404 failure
             for dev in (resp.get("body", {}).get("resources", []) or []):
                 aid = dev.get("device_id", "")
                 hostname = dev.get("hostname", "")
@@ -331,7 +332,7 @@ class AppState:
         self.bucket_counts: list[int] = [0] * NUM_BUCKETS
         self.audit_data: dict = {}
         self.loading: bool = False
-        self._refresh_pending: bool = False
+        self.refresh_pending: bool = False
         self.last_refreshed: str = ""
         self.error_message: str = ""
         self.auto_refresh_seconds: int = 0
@@ -389,7 +390,7 @@ def _worst_offenders(devices: list[DeviceRecord], n: int = 10) -> list[DeviceRec
 class ZTAScoreViewerApp:
     """Dear PyGui application for visualising Zero Trust Assessment scores."""
 
-    def __init__(self, client_id: str = "", client_secret: str = ""): # nosec - Bandit FP
+    def __init__(self, client_id: str = "", client_secret: str = ""):  # nosec - Bandit FP
         """Initialise the application, client, and state.
 
         *client_id* and *client_secret* are CLI-supplied credential overrides.
@@ -405,6 +406,7 @@ class ZTAScoreViewerApp:
         self._api_after_token: str = ""
         self._has_more_api_data: bool = False
         self._api_fetching_more: bool = False
+        self._load_more_pending: bool = False
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -438,8 +440,8 @@ class ZTAScoreViewerApp:
             dpg.render_dearpygui_frame()
             needs = False
             with self.state.lock:
-                if self.state._refresh_pending:
-                    self.state._refresh_pending = False
+                if self.state.refresh_pending:
+                    self.state.refresh_pending = False
                     needs = True
             if needs:
                 self._hide_loading()
@@ -647,7 +649,7 @@ class ZTAScoreViewerApp:
         finally:
             with self.state.lock:
                 self.state.loading = False
-                self.state._refresh_pending = True
+                self.state.refresh_pending = True
 
     def _async_load_more(self):
         """Fetch the next batch of devices using the saved API cursor."""
@@ -680,7 +682,7 @@ class ZTAScoreViewerApp:
             self._api_fetching_more = False
             with self.state.lock:
                 self.state.loading = False
-                self.state._refresh_pending = True
+                self.state.refresh_pending = True
 
     def _refresh_ui(self):
         """Rebuild all data-driven widgets from self.state.devices."""

--- a/samples/zero_trust_assessment/zta_score_viewer/zta_score_viewer.py
+++ b/samples/zero_trust_assessment/zta_score_viewer/zta_score_viewer.py
@@ -146,9 +146,10 @@ class DeviceRecord:
         platform = PLATFORM_NAMES.get(platform_code, platform_code)
         product = raw.get("product_type_desc", "")
         self.os: str = f"{platform} {product}".strip() if (platform or product) else ""
-        # Score is in assessment.overall for full records, or raw.score for score-only records
+        # Score is in assessment.overall for full records, or raw.score for score-only records.
+        # Guard against null values returned by the API (overall: null).
         self.score: float = float(
-            assessment.get("overall", raw.get("score", 0))
+            assessment.get("overall") or raw.get("score") or 0
         )
         ts = raw.get("modified_time", "")
         self.last_seen: str = ts[:19].replace("T", " ") if ts else ""
@@ -203,7 +204,7 @@ class ZTAClient:
                 self.status = "error"
                 return False
             self._sdk = sdk
-            self._hosts_sdk = Hosts(client_id=client_id, client_secret=client_secret)
+            self._hosts_sdk = Hosts(auth_object=sdk)
             self.status = "connected"
             self.error = ""
             return True
@@ -283,48 +284,6 @@ class ZTAClient:
 
         return records, (after_token or "")
 
-    def fetch_bucket_counts(self) -> list[int]:
-        """Return accurate per-bucket device counts by querying each score range.
-
-        The standard fetch_assessments() only retrieves up to *limit* devices
-        sorted ascending by score, which causes all sampled devices to fall in
-        the lowest bucket on large environments.  This method queries each
-        10-point range individually to get the true count for every bucket.
-
-        Returns a list of 11 integers: indices 0-9 = ranges 0-9…90-99,
-        index 10 = score 100.
-        """
-        if self._sdk is None:
-            return [0] * NUM_BUCKETS
-
-        counts = [0] * NUM_BUCKETS
-        for i in range(10):
-            lo = i * 10
-            hi = lo + 9
-            resp = self._sdk.getAssessmentsByScoreV1(
-                filter=f"score:>={lo}+score:<={hi}", limit=1
-            )
-            if resp.get("status_code", 0) == 200:
-                total = (
-                    resp.get("body", {})
-                    .get("meta", {})
-                    .get("pagination", {})
-                    .get("total", 0)
-                )
-                counts[i] = total
-
-        # Bucket 10: score exactly 100
-        resp100 = self._sdk.getAssessmentsByScoreV1(filter="score:>=100", limit=1)
-        if resp100.get("status_code", 0) == 200:
-            counts[10] = (
-                resp100.get("body", {})
-                .get("meta", {})
-                .get("pagination", {})
-                .get("total", 0)
-            )
-
-        return counts
-
     def fetch_hostnames(self, aids: list[str]) -> dict[str, str]:
         """Return a dict mapping AID → hostname for AIDs that resolve via Hosts API.
 
@@ -348,14 +307,14 @@ class ZTAClient:
                     result[aid] = hostname
         return result
 
-    def fetch_audit(self) -> dict:
-        """Return the raw audit report body dict, or an error body."""
+    def fetch_audit(self) -> tuple[bool, dict]:
+        """Return (success, body) for the audit report. success=False on non-200."""
         if self._sdk is None:
-            return {}
+            return False, {}
         resp = self._sdk.get_audit()
         if resp.get("status_code", 0) == 200:
-            return resp.get("body", {})
-        return resp.get("body", {})
+            return True, resp.get("body", {})
+        return False, resp.get("body", {})
 
 
 # ---------------------------------------------------------------------------
@@ -438,21 +397,14 @@ class ZTAScoreViewerApp:
         """
         self.client = ZTAClient()
         self.state = AppState()
-        # CLI credential overrides — forwarded to connect() and reconnect
         self._client_id = client_id
         self._client_secret = client_secret
-        # Dear PyGui item tags — populated during setup
-        self._tags: dict = {}
-        # Pagination state for device table
         self._page_index: int = 0
         self._page_size: int = DEFAULT_PAGE_SIZE
-        # Sorted device list (may differ from state.devices after column sort)
         self._sorted_devices: list[DeviceRecord] = []
-        # Progressive API pagination state
         self._api_after_token: str = ""
         self._has_more_api_data: bool = False
         self._api_fetching_more: bool = False
-        self._load_more_pending: bool = False  # set True when _worker_load_more completes
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -675,16 +627,16 @@ class ZTAScoreViewerApp:
         """Background worker: fetch assessments and update UI."""
         try:
             devices, next_after = self.client.fetch_assessments()
-            bucket_counts = self.client.fetch_bucket_counts()
+            bucket_counts = _build_buckets(devices)
             # Resolve hostnames for endpoint AIDs (CWPP AIDs will not resolve)
             aids = [d.aid for d in devices]
             hostname_map = self.client.fetch_hostnames(aids)
             for dev in devices:
                 dev.hostname = hostname_map.get(dev.aid, "")
             ts = datetime.now().strftime("%H:%M:%S")
-            self._api_after_token = next_after
-            self._has_more_api_data = bool(next_after)
             with self.state.lock:
+                self._api_after_token = next_after
+                self._has_more_api_data = bool(next_after)
                 self.state.devices = devices
                 self.state.bucket_counts = bucket_counts
                 self.state.last_refreshed = ts
@@ -716,10 +668,9 @@ class ZTAScoreViewerApp:
             hostname_map = self.client.fetch_hostnames(aids)
             for dev in new_devices:
                 dev.hostname = hostname_map.get(dev.aid, "")
-            self._api_after_token = next_after
-            self._has_more_api_data = bool(next_after)
-            self._load_more_pending = True
             with self.state.lock:
+                self._api_after_token = next_after
+                self._has_more_api_data = bool(next_after)
                 self.state.devices = self.state.devices + new_devices
                 self.state.error_message = ""
         except Exception as exc:  # pylint: disable=broad-except
@@ -990,8 +941,8 @@ class ZTAScoreViewerApp:
             return str(v)
 
         def _worker():
-            audit = self.client.fetch_audit()
-            if not audit:
+            ok, audit = self.client.fetch_audit()
+            if not ok or not audit:
                 dpg.set_value("audit_text", "No audit data returned or not authenticated.")
                 return
             lines = []


### PR DESCRIPTION
# Sample Bug Fixes

## alerts_triage.py

| Bug | Fix |
|-----|-----|
| `pyqtSignal(int, bool)` emitting a string. `meta.get("offset", "")` crashes at runtime | Changed default to `0` |
| No `closeEvent`. Segfault if user closes during a fetch | Added `closeEvent` that cancels and waits on workers |
| FQL time-filter detection used substring matching. `"last_"` in a hostname falsely suppressed the default time window | Changed to match `fieldname:` pattern instead |
| `Qt.CheckState.Checked.value` comparison is fragile across Qt versions | Changed to `Qt.CheckState(state) == Qt.CheckState.Checked` |

---

## device_control_policy_manager.py

| Bug | Fix |
|-----|-----|
| No `closeEvent`. Workers never stopped on close | Added `closeEvent` that waits on `_active_workers` |
| `performDeviceControlPoliciesAction` raw operation ID used alongside Pythonic names | Renamed to `perform_action` (live-verified) |
| Two SDK instances with same credentials. Double OAuth2 token exchange | Second instance now uses `auth_object=sdk` (live-verified) |
| No validation on vendor/product ID fields despite label saying "4-digit hex" | Added hex range validation in `_on_accept` |
| `ExceptionDialog` had 9 `@property` methods, each a one-liner on a throwaway dialog | Removed all properties; call site reads widget values directly |

---

## filevantage_monitor.py

| Bug | Fix |
|-----|-----|
| Debug `print()` statements fired on every auto-refresh | Removed |
| Demo fixtures used `file_path` but real API uses `entity_path`. Demo exercised the wrong code path | Updated demo fixtures to use `entity_path` |
| New SDK instance created inside `FetchChangesWorker.run()`. New OAuth2 token every 30s | SDK created once in `FileVantageWindow.__init__`, passed to workers |
| `import time` inside `SuppressWorker.run()` | Moved to top-level imports |
| `closeEvent` called `worker.wait()` with no timeout. App could hang up to 30s on close | Changed to `worker.wait(5000)` |

---

## high_activity_hosts.py

| Bug | Fix |
|-----|-----|
| `Lock` imported but never used | Removed from import |
| `os._exit()` at end of main bypasses Python shutdown | Replaced with `sys.exit()` |
| `datetime.utcnow()` deprecated since Python 3.12. Live DeprecationWarning confirmed (5 call sites) | Changed to `datetime.now(timezone.utc)` |
| `max_workers` parameter in `count_alerts_by_host` documented as unused | Removed parameter and updated all call sites |
| Demo data missing the `< 1 hour` recency tier present in real scoring | Added all three tiers (`<1h`, `<24h`, `<72h`) |

---

## ods_manager.py

| Bug | Fix |
|-----|-----|
| `_loading` flag written from background thread without lock. Race with 15s poll timer | Both read and write now protected by `self._lock` |
| `wx.MessageDialog` created inline with `.ShowModal()` but never `.Destroy()`. Native window handle leak | All dialogs now assigned to variable and `Destroy()` called after `ShowModal()` |
| Two SDK instances with same credentials. Double OAuth2 token exchange | Second instance now uses `auth_object=sdk` (live-verified) |

---

## rtr_replay.py

| Bug | Fix |
|-----|-----|
| `format_duration` annotated as `float` but checks for `None` | Changed annotation to `Optional[float]` |
| `consume_arguments` return type annotated as `object` | Changed to `-> Namespace` |
| Missing credentials silently fell back to demo mode. Typo in env var showed fake data with no warning | Demo mode now requires explicit `--demo` flag |
| `limit` cast to `str` in `call_audit_sessions`. FalconPy accepts int | Removed `str()` cast |
| Separator width inconsistency: `"=" * 70` in one function, `"-" * 68` in another | Standardised to 70 |

---

## rtr_replay_gui.py

| Bug | Fix |
|-----|-----|
| `closeEvent` called `worker.terminate()`. Same file documents this corrupts Python's GIL in urllib3/SSL | Removed `terminate()` call; OS reclaims thread on exit |
| `PrefetchWorker` created a new SDK instance on every loop iteration. New OAuth2 token per page | SDK instantiated once before the loop |
| `SessionFilterProxy` was an empty subclass of `QSortFilterProxyModel` with no methods | Removed; replaced with `QSortFilterProxyModel` directly |
| Easter egg (`_ClickableLabel`, `_show_easter_egg`, `_PUNK_SPIDER_PATH`) in a production sample | Removed |
| `consume_arguments` return type annotated as `object` | Changed to `-> Namespace` |

---

## spotlight_vuln_dashboard.py

| Bug | Fix |
|-----|-----|
| `_build_fql` function defined but never called | Removed |
| Double-click handler used visual row index into `_filtered_records`. Opens wrong CVE after sorting | Record now stored in `Qt.UserRole` at insert time; handler reads from there |
| URL construction for named regions was wrong. `"us1"` produced `https://api.us1.crowdstrike.com` | Pass region string directly to FalconPy; SDK handles resolution (live-verified) |
| `_after_token` assigned then immediately suppressed with `# noqa: F841` | Removed the unused variable |
| Two SDK instances with same credentials. Double OAuth2 token exchange | Second instance now uses `auth_object=sdk` (live-verified) |

---

## tailored_intel_browser.py

| Bug | Fix |
|-----|-----|
| `_scrub_credentials_from_argv` mutated `sys.argv` then `KIVY_NO_ARGS="1"` was set immediately after, making the mutation pointless | Removed scrub function; `KIVY_NO_ARGS` set before Kivy imports, standard `argparse` used in `main()` |
| 80-line Lua-table parser handling a format the API does not return | Replaced with a simple `json.loads` call |
| `datetime.utcfromtimestamp` deprecated since Python 3.12. Live DeprecationWarning confirmed | Changed to `datetime.fromtimestamp(ts, tz=timezone.utc)` |
| `import re` and `import sys` with no usage | Removed |
| `EventRecord._raw` stored a reference to the raw dict. Caller mutation changed stored data | Changed to `dict(raw)` copy |
| `TabButton` Python class had no methods or properties | Removed |

---

## zta_score_viewer.py

| Bug | Fix |
|-----|-----|
| `fetch_bucket_counts` made 11 separate API calls; `_build_buckets` did the same client-side for free | Deleted `fetch_bucket_counts`; call sites now use `_build_buckets` |
| `_api_after_token` and `_has_more_api_data` written from background thread without lock | Writes moved inside `with self.state.lock` |
| `float(None)` crash when API returns `overall: null`. Confirmed live with `TypeError` | Changed to `float(assessment.get("overall") or raw.get("score") or 0)` |
| `fetch_audit` returned identical value for both success and failure. Caller could not distinguish | Changed return type to `tuple[bool, dict]`; success returns `(True, body)` |
| Two SDK instances with same credentials. Double OAuth2 token exchange | Second instance now uses `auth_object=sdk` (live-verified) |
| `_refresh_pending` accessed as protected member outside `AppState` | Renamed to `refresh_pending` (public) |
