### PR TITLE
Feature/add workflow definitions delete

### DIFF
--- a/src/falconpy/_endpoint/_workflows.py
+++ b/src/falconpy/_endpoint/_workflows.py
@@ -306,6 +306,28 @@ _workflows_endpoints = [
     ]
   ],
   [
+    "WorkflowDefinitionsDelete",
+    "DELETE",
+    "/workflows/entities/definitions/v1",
+    "Accepts a list of workflow definition IDs and deletes those definitions and all their associated versions.",
+    "workflows",
+    [
+      {
+        "maxItems": 5000,
+        "minItems": 1,
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "collectionFormat": "multi",
+        "description": "IDs of the workflow definitions to delete",
+        "name": "ids",
+        "in": "query",
+        "required": True
+      }
+    ]
+  ],
+  [
     "WorkflowExecuteInternal",
     "POST",
     "/workflows/entities/execute/internal/v1",

--- a/src/falconpy/workflows.py
+++ b/src/falconpy/workflows.py
@@ -349,6 +349,37 @@ class Workflows(ServiceClass):
             body=body
             )
 
+    @force_default(defaults=["parameters"], default_types=["dict"])
+    def delete_definitions(self: object,
+                           *args,
+                           parameters: dict = None,
+                           **kwargs
+                           ) -> Union[Dict[str, Union[int, dict]], Result]:
+        """Delete workflow definitions and all their associated versions.
+
+        Keyword arguments:
+        ids -- IDs of workflow definitions to delete. String or List of Strings.
+        parameters -- Full parameters payload dictionary. Not required if ids is
+                      provided as a keyword.
+
+        Arguments: When not specified, the first argument to this method is assumed to be 'ids'.
+                   All others are ignored.
+
+        Returns: dict object containing API response.
+
+        HTTP Method: DELETE
+
+        Swagger URL
+        https://assets.falcon.crowdstrike.com/support/api/swagger.html#/workflows/WorkflowDefinitionsDelete
+        """
+        return process_service_request(
+            calling_object=self,
+            endpoints=Endpoints,
+            operation_id="WorkflowDefinitionsDelete",
+            keywords=kwargs,
+            params=handle_single_argument(args, parameters, "ids")
+            )
+
     @force_default(defaults=["body", "parameters"], default_types=["dict", "dict"])
     def execute(self: object,
                 body: dict = None,
@@ -983,6 +1014,7 @@ class Workflows(ServiceClass):
     WorkflowExecutionResults = execution_results
     WorkflowGetHumanInputV1 = get_human_input
     WorkflowUpdateHumanInputV1 = update_human_input
+    WorkflowDefinitionsDelete = delete_definitions
     WorkflowSystemDefinitionsDeProvision = deprovision
     WorkflowSystemDefinitionsPromote = promote
     WorkflowSystemDefinitionsProvision = provision

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -49,7 +49,8 @@ class TestWorkflows:
             "WorkflowUpdateHumanInputV1": falcon.update_human_input(input="whatever", note="whatever"),
             "WorkflowActivitiesContentCombined": falcon.search_activities_content(limit=1),
             "WorkflowExecuteSingleNodeV1": falcon.execute_single_activity_node(definition = {"Definition": {}}, definition_id="12345678", execution_cid="12345678", depth=1),
-            "QueryChildExecutions": falcon.query_child_executions(filter="status:'running'", limit=10, offset=0)
+            "QueryChildExecutions": falcon.query_child_executions(filter="status:'running'", limit=10, offset=0),
+            "WorkflowDefinitionsDelete": falcon.delete_definitions(ids="12345678")
         }
         for key in tests:
             if tests[key]["status_code"] not in AllowedResponses:


### PR DESCRIPTION
## feat: Add WorkflowDefinitionsDelete endpoint

Add support for `DELETE /workflows/entities/definitions/v1` which accepts a list of workflow definition IDs and deletes those definitions along with all their associated versions.

- Added endpoint definition to `_endpoint/_workflows.py`
- Added `delete_definitions()` method to Workflows service class
- Added `WorkflowDefinitionsDelete` operation ID alias for backwards compatibility
- Added unit test to `tests/test_workflows.py`


- [X] Enhancement
- [X] Documentation


#### Unit test coverage
```shell
Unit test added to tests/test_workflows.py following existing patterns.
Local execution requires CI credentials (test_authorization config).
Test validates WorkflowDefinitionsDelete returns an allowed status code (200/400/403/404).

Endpoint manually tested against live CrowdStrike API:
- DELETE /workflows/entities/definitions/v1?ids=5ce4fba2... → 200 (resources_affected: 1)
- Verified deletion via search_definitions → [] (confirmed removed)
```

#### Bandit analysis
```shell
[main]  INFO    running on Python 3.13.11
Run started:2026-04-29 19:03:25.722347+00:00

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 1609
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
Files skipped (0):
```
## Added features and functionality
+ Added `Workflows.delete_definitions()` method — enables programmatic deletion of workflow definitions via `DELETE /workflows/entities/definitions/v1`
+ Added `WorkflowDefinitionsDelete` operation ID alias for Service Class and Uber Class usage

## Issues resolved
+ No existing issue — this endpoint is present in the CrowdStrike Swagger specification but was missing from the FalconPy SDK (gap identified via automated spec-to-SDK comparison)

## Other
+ Endpoint spec: `DELETE /workflows/entities/definitions/v1`, accepts `ids` query parameter (array, max 5000)
+ Follows existing SDK conventions: `handle_single_argument`, `force_default`, PascalCase alias
+ Validated against live CrowdStrike API — successfully deleted workflow definitions and confirmed removal
