### PR TITLE
fix: return a standard error body for non-JSON error responses

### DIFF
--- a/src/falconpy/_constant/__init__.py
+++ b/src/falconpy/_constant/__init__.py
@@ -77,3 +77,5 @@ MAX_TOKEN_RENEW_WINDOW: int = 1200
 MIN_TOKEN_RENEW_WINDOW: int = 120
 # Maximum length for strings generated with the random_string function (in seconds).
 MAX_RANDOM_STRING_LENGTH: int = 4096
+# Maximum length of a non-JSON error payload retained in a generated error message.
+MAX_ERROR_PAYLOAD_LENGTH: int = 4096

--- a/src/falconpy/_util/_functions.py
+++ b/src/falconpy/_util/_functions.py
@@ -61,7 +61,8 @@ from .._constant import (
     ALLOWED_METHODS as _ALLOWED_METHODS,
     USER_AGENT as _USER_AGENT,
     MAX_DEBUG_RECORDS,
-    GLOBAL_API_MAX_RETURN
+    GLOBAL_API_MAX_RETURN,
+    MAX_ERROR_PAYLOAD_LENGTH
 )
 from .._error import (
     RegionSelectError,
@@ -325,6 +326,16 @@ def calc_content_return(resp: requests.Response,
     # Catch and log API response errors
     try:
         if resp.status_code >= 400:
+            if not isinstance(returned, dict):
+                # An error was returned as content we could not parse as JSON,
+                # leaving us with a binary payload. Normalize it to the standard
+                # error format so the status code and the response headers - which
+                # carry the trace ID needed to research the failure - are retained
+                # instead of being discarded by an unhandled exception. (Issue #1508)
+                returned = Result()(status_code=resp.status_code,
+                                    headers=resp.headers,
+                                    body=build_error_body_from_payload(returned, resp.status_code)
+                                    )
             _message = None
             _errors = returned.get("body", {}).get("errors", [])
             if _errors:
@@ -545,6 +556,26 @@ def log_api_activity(content_return: Union[dict, bytes], content_type: str, api:
             api.log_util.debug("RESULT: %s", content_return)
         else:
             api.log_util.debug("RESULT: binary response received from API")
+
+
+def build_error_body_from_payload(payload: Union[bytes, str], status_code: int) -> dict:
+    """Wrap a non-JSON response payload in the standard error format.
+
+    Error responses are not always JSON. Proxies, load balancers and WAF
+    appliances positioned in front of the API can answer with HTML error
+    pages, empty bodies or unexpected content types. These payloads reach
+    the SDK as raw binary content instead of a dictionary. (Issue #1508)
+    """
+    if isinstance(payload, bytes):
+        message = payload.decode("utf-8", errors="replace").strip()
+    else:
+        message = str(payload).strip()
+    if not message:
+        message = "No content was received for this request."
+    if len(message) > MAX_ERROR_PAYLOAD_LENGTH:
+        message = f"{message[:MAX_ERROR_PAYLOAD_LENGTH]}..."
+
+    return {"errors": [{"code": status_code, "message": message}], "resources": []}
 
 
 def generate_error_result(

--- a/tests/test_non_json_error_responses.py
+++ b/tests/test_non_json_error_responses.py
@@ -1,0 +1,153 @@
+# test_non_json_error_responses.py
+# This class tests handling of error responses that do not contain JSON (Issue #1508)
+import os
+import sys
+from unittest.mock import patch
+import pytest
+import requests
+# Import our sibling src folder into the path
+sys.path.append(os.path.abspath('src'))
+# Classes to test - manually imported from sibling folder
+from falconpy._util._functions import build_error_body_from_payload, calc_content_return
+from falconpy._constant import MAX_ERROR_PAYLOAD_LENGTH
+from falconpy._error import APIError
+from falconpy import UserManagement, APIHarnessV2
+
+# A gateway error page, the most common cause of a non-JSON error response.
+_HTML_ERROR = b"<html><head><title>502 Bad Gateway</title></head><body>502</body></html>"
+_TRACE_ID = "8f14e45f-ea8a-42f6-9e2b-1c3d4e5f6a7b"
+
+
+def build_response(status_code: int, content_type, content: bytes) -> requests.Response:
+    """Create a requests.Response without performing a live API call."""
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = content
+    response.headers["X-Cs-Traceid"] = _TRACE_ID
+    if content_type:
+        response.headers["Content-Type"] = content_type
+
+    return response
+
+
+def content_return(response: requests.Response, pythonic: bool = False):
+    """Call the response handler with the defaults used by a standard request."""
+    return calc_content_return(resp=response,
+                               contain=False,
+                               auth=False,
+                               log=None,
+                               pythonic_mode=pythonic,
+                               api_method="POST"
+                               )
+
+
+class TestNonJSONErrorResponses:
+    """Confirm error responses that are not JSON return the documented structure."""
+
+    @pytest.mark.parametrize("status_code,content_type,content", [
+        (502, "text/html", _HTML_ERROR),                     # Gateway error page
+        (503, None, b""),                                    # Empty body, no Content-Type
+        (500, "application/octet-stream", b"\x00\x01\x02"),  # Unexpected content type
+        (429, "text/html", b"<html>Too Many Requests</html>")  # Rate limit page
+    ])
+    def test_non_json_error_returns_standard_structure(self, status_code, content_type, content):
+        """A non-JSON error response returns a dictionary instead of raising."""
+        returned, _ = content_return(build_response(status_code, content_type, content))
+
+        assert isinstance(returned, dict)
+        # The status code reported by the API is retained, not replaced with a 500.
+        assert returned["status_code"] == status_code
+        # Headers are retained so the trace ID remains available for support requests.
+        assert returned["headers"]["X-Cs-Traceid"] == _TRACE_ID
+        assert isinstance(returned["body"], dict)
+        assert returned["body"]["errors"][0]["code"] == status_code
+        assert returned["body"]["errors"][0]["message"]
+        assert returned["body"]["resources"] == []
+
+    def test_error_message_contains_response_payload(self):
+        """The payload returned by the API is surfaced within the error message."""
+        returned, _ = content_return(build_response(502, "text/html", _HTML_ERROR))
+
+        assert "502 Bad Gateway" in returned["body"]["errors"][0]["message"]
+
+    def test_empty_payload_reports_no_content(self):
+        """An error with no payload reports that no content was received."""
+        returned, _ = content_return(build_response(503, None, b""))
+
+        assert returned["body"]["errors"][0]["message"] == "No content was received for this request."
+
+    def test_successful_binary_response_is_unchanged(self):
+        """A successful binary response is still returned as raw bytes."""
+        returned, _ = content_return(build_response(200, "application/octet-stream", b"\x50\x4b\x03\x04"))
+
+        assert isinstance(returned, bytes)
+        assert returned == b"\x50\x4b\x03\x04"
+
+    def test_json_error_response_is_unchanged(self):
+        """An error that does contain JSON is not modified."""
+        body = b'{"meta": {"trace_id": "1"}, "errors": [{"code": 403, "message": "access denied"}], "resources": []}'
+        returned, _ = content_return(build_response(403, "application/json", body))
+
+        assert returned["body"]["errors"][0]["message"] == "access denied"
+        assert returned["body"]["meta"]["trace_id"] == "1"
+
+    def test_pythonic_mode_raises_with_payload(self):
+        """Pythonic mode raises an APIError describing the failure."""
+        with pytest.raises(APIError) as raised:
+            content_return(build_response(502, "text/html", _HTML_ERROR), pythonic=True)
+
+        assert raised.value.code == 502
+        assert "502 Bad Gateway" in raised.value.message
+
+
+class TestErrorBodyGeneration:
+    """Confirm generated error bodies are well formed."""
+
+    def test_oversized_payload_is_truncated(self):
+        """A payload larger than the maximum length is truncated."""
+        returned = build_error_body_from_payload(b"A" * (MAX_ERROR_PAYLOAD_LENGTH + 100), 502)
+        message = returned["errors"][0]["message"]
+
+        assert len(message) == MAX_ERROR_PAYLOAD_LENGTH + 3
+        assert message.endswith("...")
+
+    def test_undecodable_payload_does_not_raise(self):
+        """A payload that is not valid UTF-8 is decoded without raising."""
+        returned = build_error_body_from_payload(b"\xff\xfe binary payload", 500)
+
+        assert "binary payload" in returned["errors"][0]["message"]
+
+    def test_string_payload_is_accepted(self):
+        """A payload that has already been decoded is handled."""
+        returned = build_error_body_from_payload("  upstream connect error  ", 503)
+
+        assert returned["errors"][0] == {"code": 503, "message": "upstream connect error"}
+
+
+class TestNonJSONErrorResponsesByClass:
+    """Confirm both class styles return the documented structure."""
+
+    @staticmethod
+    def gateway_error(*args, **kwargs) -> requests.Response:
+        """Return a gateway error page in place of a live API response."""
+        return build_response(502, "text/html", _HTML_ERROR)
+
+    def test_service_class(self):
+        """A Service Class returns the error structure instead of a generated 500."""
+        with patch("requests.request", self.gateway_error):
+            falcon = UserManagement(access_token="testing", base_url="https://api.crowdstrike.com")
+            returned = falcon.grant_user_role_ids(role_ids=["role"], user_uuid="uuid")
+
+        assert returned["status_code"] == 502
+        assert returned["headers"]["X-Cs-Traceid"] == _TRACE_ID
+        assert "502 Bad Gateway" in returned["body"]["errors"][0]["message"]
+
+    def test_uber_class(self):
+        """The Uber Class returns the error structure instead of a generated 500."""
+        with patch("requests.request", self.gateway_error):
+            falcon = APIHarnessV2(access_token="testing", base_url="https://api.crowdstrike.com")
+            returned = falcon.command("GrantUserRoleIds", user_uuid="uuid", body={"roleIds": ["role"]})
+
+        assert returned["status_code"] == 502
+        assert returned["headers"]["X-Cs-Traceid"] == _TRACE_ID
+        assert "502 Bad Gateway" in returned["body"]["errors"][0]["message"]


### PR DESCRIPTION
## Return a standard error body for non-JSON error responses

Error responses are not always JSON. A proxy, load balancer or WAF sitting in front of the API can answer with an HTML error page, an empty body or an unexpected content type. Those payloads reach `calc_content_return()` as raw bytes, and the error inspection block then calls `.get()` on them:

```python
if resp.status_code >= 400:
    _message = None
    _errors = returned.get("body", {}).get("errors", [])
```

which raises `AttributeError: 'bytes' object has no attribute 'get'`. The exception is caught by the general handler in `perform_request()`, wrapped in an `SDKError` (whose code defaults to 500) and returned as a generated error, so the real status code and every response header, including `X-Cs-TraceId`, are discarded. That is the loss reported in #1508: the caller cannot tell a 429 from a 502 from a 503, and Support has no trace ID to research.

- [x] Bug fixes
- [x] Updated unit tests

### Reproduction

Four conditions reach the failing line on `main` (1.6.5). All four require `status_code >= 400` **and** a body that is not JSON or `text/plain`:

| Response | 1.6.5 |
| :-- | :-- |
| 502, `text/html` gateway page | `AttributeError` |
| 503, empty body, no `Content-Type` | `AttributeError` |
| 500, `application/octet-stream` | `AttributeError` |
| 429, `text/html` rate limit page | `AttributeError` |

End to end through the operation named in the issue, before the change:

```python
{'status_code': 500, 'headers': {}, 'body': {'errors': [{'message': "'bytes' object has no attribute 'get'", 'code': 500}], 'resources': []}}
```

and after:

```python
{'status_code': 502, 'headers': {'Content-Type': 'text/html', 'X-Cs-Traceid': 'trace-abc-123'}, 'body': {'errors': [{'code': 502, 'message': '<html>...502 Bad Gateway...</html>'}], 'resources': []}}
```

Both Service Classes and `APIHarnessV2` reach this through the same function, so both were affected and both are fixed.

### Behaviour change

A response with `status_code >= 400` whose body is not JSON or `text/plain` previously raised, and now returns the documented `status_code` / `headers` / `body` dictionary with a Falcon shaped `errors` list.

The guard is nested inside the existing `status_code >= 400` branch, so **successful binary responses are untouched**. RTR file get, sensor downloads and report exports still return raw bytes. There is a unit test asserting this.

### Relationship to #1428

PR #1428 is open against the same function for a different issue (#1154). I checked it out and ran the reproduction against it: it resolves the two `text/html` cases as a side effect of adding a `text/html` branch, and leaves the empty body and `application/octet-stream` cases raising, because it does not change the `.get()` call. The two changes are complementary rather than competing, and I do not believe they conflict textually. Happy to rebase on it, fold this into it, or step aside if you would rather see that one land first.

#### Unit test coverage

`tests/test_non_json_error_responses.py` is new: 14 tests built on stubbed `requests.Response` objects, requiring no credentials.

```shell
$ coverage run --source=src --omit=src/falconpy/debug.py -m pytest tests/test_non_json_error_responses.py -q
14 passed, 1 warning in 0.14s

Name                                   Stmts   Miss  Cover
-------------------------------------------------------------
src/falconpy/_constant/__init__.py        13      0   100%
src/falconpy/_util/_functions.py         475    244    49%
```

Every line added by this PR is covered by this file alone. The 49% figure is this one test file in isolation; the rest of the module is exercised by the credentialed suite, which does not run on fork pull requests (the unit testing workflows are gated on `head.repo.full_name == github.repository`), so I could not produce a full series result. Removing the guard and rerunning the new file fails 8 of 14, each with the original `AttributeError`.

#### Bandit analysis

```shell
$ bandit -r src/falconpy
Total lines of code: 155107

Total issues (by severity):
    Undefined: 0
    Low: 0
    Medium: 0
    High: 0
```

`flake8 src/falconpy --count` reports 0. `pylint` on the changed module scores 9.80 against a 9.79 baseline on `main`.

## Issues resolved

* Fixes https://github.com/CrowdStrike/falconpy/issues/1508 by normalizing a non-dictionary payload into the standard error format before the error inspection block reads it, so the status code and headers of the original response are retained.

## Other

+ `build_error_body_from_payload()` decodes with `errors="replace"` so an error page that is not valid UTF-8 cannot raise from inside error handling, and truncates at `MAX_ERROR_PAYLOAD_LENGTH` (4096) so a large HTML page is not embedded whole into an error message.
+ It is not exported from `_util/__init__.py` since nothing outside `_functions.py` uses it. Happy to export it if you would prefer.
+ No version bump included, assuming that is maintainer managed.
